### PR TITLE
[api] Create LLVMIntTypeInContext bindings

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/Context.kt
@@ -81,6 +81,8 @@ public class Context internal constructor(private val llvmCtx: LLVMContextRef) :
     /**
      * Register a yield callback with the given context.
      *
+     * TODO: Find out how to actually call this thing from Kotlin/Java
+     *
      * @param callback Callback to register. C++ Type: void (*)(LLVMContext *Context, void *OpaqueHandle)
      * @param opaqueHandle Pointer type: void*
      *

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/IntegerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/IntegerType.kt
@@ -41,7 +41,7 @@ object IntegerType {
     public fun i16Type(context: LLVMContextRef): LLVMTypeRef {
         require(!context.isNull)
 
-        return LLVM.LLVMInt32TypeInContext(context)
+        return LLVM.LLVMInt16TypeInContext(context)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/IntegerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/IntegerType.kt
@@ -1,0 +1,95 @@
+package dev.supergrecko.kllvm.core.type
+
+import org.bytedeco.llvm.LLVM.LLVMContextRef
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+/**
+ * Wrapper around llvm::IntegerType
+ */
+object IntegerType {
+    /**
+     * Obtain an i1 type from a context with specified bit width.
+     *
+     * - [LLVMInt1TypeInContext](https://llvm.org/doxygen/group__LLVMCCoreTypeInt.html#ga390b4c486c780eed40002b07933d13df)
+     */
+    public fun i1Type(): LLVMTypeRef = i1Type(LLVM.LLVMGetGlobalContext())
+    public fun i1Type(context: LLVMContextRef): LLVMTypeRef {
+        require(!context.isNull)
+
+        return LLVM.LLVMInt1TypeInContext(context)
+    }
+
+    /**
+     * Obtain an i8 type from a context with specified bit width.
+     *
+     * - [LLVMInt8TypeInContext](https://llvm.org/doxygen/group__LLVMCCoreTypeInt.html#ga7afaa9a2cb5dd3c5c06d65298ed195d4)
+     */
+    public fun i8Type(): LLVMTypeRef = i8Type(LLVM.LLVMGetGlobalContext())
+    public fun i8Type(context: LLVMContextRef): LLVMTypeRef {
+        require(!context.isNull)
+
+        return LLVM.LLVMInt8TypeInContext(context)
+    }
+
+    /**
+     * Obtain an i16 type from a context with specified bit width.
+     *
+     * - [LLVMInt16TypeInContext](https://llvm.org/doxygen/group__LLVMCCoreTypeInt.html#ga23a21172a069470b344a61672b299968)
+     */
+    public fun i16Type(): LLVMTypeRef = i16Type(LLVM.LLVMGetGlobalContext())
+    public fun i16Type(context: LLVMContextRef): LLVMTypeRef {
+        require(!context.isNull)
+
+        return LLVM.LLVMInt32TypeInContext(context)
+    }
+
+    /**
+     * Obtain an i32 type from a context with specified bit width.
+     *
+     * - [LLVMInt32TypeInContext](https://llvm.org/doxygen/group__LLVMCCoreTypeInt.html#ga5e69a2cc779db154a0b805ed6ad3c724)
+     */
+    public fun i32Type(): LLVMTypeRef = i32Type(LLVM.LLVMGetGlobalContext())
+    public fun i32Type(context: LLVMContextRef): LLVMTypeRef {
+        require(!context.isNull)
+
+        return LLVM.LLVMInt32TypeInContext(context)
+    }
+
+    /**
+     * Obtain an i64 type from a context with specified bit width.
+     *
+     * - [LLVMInt64TypeInContext](https://llvm.org/doxygen/group__LLVMCCoreTypeInt.html#ga23a21172a069470b344a61672b299968)
+     */
+    public fun i64Type(): LLVMTypeRef = i64Type(LLVM.LLVMGetGlobalContext())
+    public fun i64Type(context: LLVMContextRef): LLVMTypeRef {
+        require(!context.isNull)
+
+        return LLVM.LLVMInt64TypeInContext(context)
+    }
+
+    /**
+     * Obtain an i128 type from a context with specified bit width.
+     *
+     * - [LLVMInt128TypeInContext](https://llvm.org/doxygen/group__LLVMCCoreTypeInt.html#ga5f3cfd960e39ae448213d45db5da229a)
+     */
+    public fun i128Type(): LLVMTypeRef = i128Type(LLVM.LLVMGetGlobalContext())
+    public fun i128Type(context: LLVMContextRef): LLVMTypeRef {
+        require(!context.isNull)
+
+        return LLVM.LLVMInt128TypeInContext(context)
+    }
+
+    /**
+     * Obtain an integer type from a context with specified bit width.
+     *
+     * - [LLVMIntIntTypeInContext](https://llvm.org/doxygen/group__LLVMCCoreTypeInt.html#ga2e5db8cbc30daa156083f2c42989138d)
+     */
+    public fun iType(size: Int): LLVMTypeRef = iType(size, LLVM.LLVMGetGlobalContext())
+    public fun iType(size: Int, context: LLVMContextRef): LLVMTypeRef {
+        require(!context.isNull)
+        require(size > 0)
+
+        return LLVM.LLVMIntTypeInContext(context, size)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/IntegerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/IntegerType.kt
@@ -88,8 +88,16 @@ object IntegerType {
     public fun iType(size: Int): LLVMTypeRef = iType(size, LLVM.LLVMGetGlobalContext())
     public fun iType(size: Int, context: LLVMContextRef): LLVMTypeRef {
         require(!context.isNull)
-        require(size > 0)
+        require(size in 1..8388606) { "LLVM only supports integers of 2^23-1 bits size" }
 
-        return LLVM.LLVMIntTypeInContext(context, size)
+        return when (size) {
+            128 -> i128Type(context)
+            64 -> i64Type(context)
+            32 -> i32Type(context)
+            16 -> i16Type(context)
+            8 -> i8Type(context)
+            1 -> i1Type(context)
+            else -> LLVM.LLVMIntTypeInContext(context, size)
+        }
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/utils/RunAll.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/utils/RunAll.kt
@@ -1,0 +1,8 @@
+package dev.supergrecko.kllvm.utils
+
+/**
+ * Run executor over all subjects used for tests
+ */
+internal fun <T> runAll(vararg subjects: T, handler: (item: T) -> Unit) {
+    subjects.forEach { handler(it) }
+}

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
@@ -1,0 +1,28 @@
+package dev.supergrecko.kllvm.core
+
+import org.junit.jupiter.api.Test
+import java.lang.IllegalArgumentException
+import kotlin.test.assertFailsWith
+
+class ContextTest {
+    @Test
+    fun `fails to reuse dropped context`() {
+        val ctx = Context.create()
+        ctx.dispose()
+
+        assertFailsWith<IllegalArgumentException> {
+            ctx.getDiagnosticHandler()
+        }
+    }
+
+    @Test
+    fun `dropping context twice fails`() {
+        val ctx = Context.create()
+
+        ctx.dispose()
+
+        assertFailsWith<IllegalArgumentException> {
+            Context.disposeContext(ctx)
+        }
+    }
+}

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.core
 
+import dev.supergrecko.kllvm.utils.runAll
 import org.bytedeco.llvm.global.LLVM
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -30,9 +31,8 @@ class ContextTest {
     @Test
     fun `modifying discard value names actually works`() {
         val ctx = Context.create()
-        val values = listOf(true, false)
 
-        values.forEach {
+        runAll(true, false) {
             ctx.setDiscardValueNames(it)
             assertEquals(it, ctx.shouldDiscardValueNames())
         }
@@ -41,9 +41,8 @@ class ContextTest {
     @Test
     fun `get integer types from llvm`() {
         val ctx = Context.create()
-        val sizes = listOf(1, 8, 16, 32, 64, 128, /* LLVMGetIntType */ 256, 1024)
 
-        sizes.forEach {
+        runAll(1, 6, 16, 32, 64, 8237, 64362) {
             val type = ctx.iType(it)
             assertEquals(it, LLVM.LLVMGetIntTypeWidth(type))
         }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
@@ -1,7 +1,8 @@
 package dev.supergrecko.kllvm.core
 
+import org.bytedeco.llvm.global.LLVM
 import org.junit.jupiter.api.Test
-import java.lang.IllegalArgumentException
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class ContextTest {
@@ -23,6 +24,28 @@ class ContextTest {
 
         assertFailsWith<IllegalArgumentException> {
             Context.disposeContext(ctx)
+        }
+    }
+
+    @Test
+    fun `modifying discard value names actually works`() {
+        val ctx = Context.create()
+        val values = listOf(true, false)
+
+        values.forEach {
+            ctx.setDiscardValueNames(it)
+            assertEquals(it, ctx.shouldDiscardValueNames())
+        }
+    }
+
+    @Test
+    fun `get integer types from llvm`() {
+        val ctx = Context.create()
+        val sizes = listOf(1, 8, 16, 32, 64, 128, /* LLVMGetIntType */ 256, 1024)
+
+        sizes.forEach {
+            val type = ctx.iType(it)
+            assertEquals(it, LLVM.LLVMGetIntTypeWidth(type))
         }
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/IntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/IntegerTypeTest.kt
@@ -1,0 +1,21 @@
+package dev.supergrecko.kllvm.core.type
+
+import dev.supergrecko.kllvm.core.Context
+import dev.supergrecko.kllvm.utils.runAll
+import org.bytedeco.llvm.global.LLVM
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class IntegerTypeTest {
+    @Test
+    fun `global module values equate to module values`() {
+        val ctx = Context.create()
+
+        runAll(1, 8, 16, 32, 64, 128) {
+            val contextType = ctx.iType(it)
+            val globalType = IntegerType.iType(it)
+
+            assertEquals(LLVM.LLVMGetIntTypeWidth(contextType), LLVM.LLVMGetIntTypeWidth(globalType))
+        }
+    }
+}

--- a/src/test/kotlin/dev/supergrecko/kllvm/utils/ConversionsTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/utils/ConversionsTest.kt
@@ -1,0 +1,18 @@
+package dev.supergrecko.kllvm.utils
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ConversionsTest {
+    @Test
+    fun `int to bool`() {
+        assertEquals(true, 1.toBoolean())
+        assertEquals(false, 0.toBoolean())
+    }
+
+    @Test
+    fun `bool to int`() {
+        assertEquals(1, true.toInt())
+        assertEquals(0, false.toInt())
+    }
+}


### PR DESCRIPTION
Implements pulling LLVM IntegerTypes from inside and outside Context.

**Implemented APIs**

- LLVMInt1TypeInContext
- LLVMInt8TypeInContext
- LLVMInt16TypeInContext
- LLVMInt32TypeInContext
- LLVMInt64TypeInContext
- LLVMInt128TypeInContext
- LLVMIntTypeInContext

**Usage**

You may receive a LLVMTypeRef based on the wanted size.

```kotlin
val ctx = Context()
val i64 = Context.iType(64) // LLVMInt64Type
```
