### PR TITLE
[ci] Make it easier to check test results for Actions

### DIFF
--- a/.github/workflows/unit-osx.yml
+++ b/.github/workflows/unit-osx.yml
@@ -14,9 +14,14 @@ jobs:
           java-version: 8
           java-package: jdk
           architecture: ${{ matrix.architecture }}
-      - run: |
+      - name: Install LLVM
+        run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
           eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
           brew install llvm
+      - name: Package Fatjar
+        run: |
           mvn clean package
+      - name: Run tests
+        run: |
           mvn clean test

--- a/.github/workflows/unit-ubuntu.yml
+++ b/.github/workflows/unit-ubuntu.yml
@@ -14,7 +14,12 @@ jobs:
           java-version: 8
           java-package: jdk
           architecture: ${{ matrix.architecture }}
-      - run: |
+      - name: Install LLVM
+        run: |
           sudo apt install llvm build-essential clang
+      - name: Package Fatjar
+        run: |
           mvn clean package
+      - name: Run tests
+        run: |
           mvn clean test


### PR DESCRIPTION
Currently the maven execution is in the same run block as the LLVM installation which makes the output log suuuuper long (10k+ lines). This splits it up.