### PR TITLE
[ci] Run on two different LLVM versions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,16 +7,19 @@ jobs:
       matrix:
         architecture: [x64, x86]
         operating-system: [macos-latest, windows-latest, ubuntu-latest, ubuntu-16.04]
-        java-version: [8, 11]
+        # Bytedeco LLVM versions
+        llvm-version: [8.0.0-1.5.1, 9.0.0-1.5.2]
     runs-on: ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: 8
           java-package: jdk
           architecture: ${{ matrix.architecture }}
       - name: Install LLVM
+        env:
+          LLVM_VERSION: ${{ matrix.llvm-version }}
         run: |
           gradle build --refresh-dependencies
       - name: Run tests

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,11 @@ repositories {
     }
 }
 
+def llvmVersion = System.getenv("LLVM_VERSION") ?: "9.0.0-1.5.2"
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.70"
-    compile "org.bytedeco:llvm-platform:9.0.0-1.5.2"
+    compile "org.bytedeco:llvm-platform:${llvmVersion}"
 
     testCompile "org.jetbrains.kotlin:kotlin-test:1.3.70"
     testCompile "org.junit.jupiter:junit-jupiter-engine:5.2.0"


### PR DESCRIPTION
This modifies the workflow file to be able to run multiple versions of LLVM.

As of right now, only 8.0.0 and 9.0.0 are being ran.