### PR TITLE
[gradle] Add dokka script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.3.70"
     id "com.github.johnrengelman.shadow" version "5.2.0"
+    id "org.jetbrains.dokka" version "0.10.1"
 }
 
 repositories {
@@ -21,6 +22,11 @@ dependencies {
 
     testCompile "org.jetbrains.kotlin:kotlin-test:1.3.70"
     testCompile "org.junit.jupiter:junit-jupiter-engine:5.2.0"
+}
+
+dokka {
+    outputFormat = 'html'
+    outputDirectory = "$buildDir/dokka"
 }
 
 compileKotlin {


### PR DESCRIPTION
This adds the dokka plugin for generating javadoc/kdoc html via gradle.