### PR TITLE
[api] Create bindings for LLVMFunctionType creation

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/contracts/Disposable.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/contracts/Disposable.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.contracts
+
+internal interface Disposable : Validatable {
+    public fun dispose()
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/contracts/TypeFactory.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/contracts/TypeFactory.kt
@@ -1,0 +1,9 @@
+package dev.supergrecko.kllvm.contracts
+
+internal interface TypeFactory<T>
+
+internal interface ScalarTypeFactory<T, K> : TypeFactory<T> {
+    public fun type(kind: K): T
+}
+
+internal interface CompositeTypeFactory<T> : TypeFactory<T>

--- a/src/main/kotlin/dev/supergrecko/kllvm/contracts/Validateable.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/contracts/Validateable.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.contracts
+
+internal interface Validatable {
+    public var valid: Boolean
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFloatType.kt
@@ -1,11 +1,12 @@
 package dev.supergrecko.kllvm.core.type
 
+import dev.supergrecko.kllvm.contracts.ScalarTypeFactory
 import org.bytedeco.llvm.LLVM.LLVMContextRef
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class LLVMFloatType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
-    companion object : TypeFactory<LLVMFloatType, FloatTypeKinds> {
+    public companion object : ScalarTypeFactory<LLVMFloatType, FloatTypeKinds> {
         /**
          * Create a float in the global context
          *

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionType.kt
@@ -1,0 +1,27 @@
+package dev.supergrecko.kllvm.core.type
+
+import dev.supergrecko.kllvm.contracts.CompositeTypeFactory
+import dev.supergrecko.kllvm.utils.toInt
+import org.bytedeco.javacpp.PointerPointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+public class LLVMFunctionType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public companion object : CompositeTypeFactory<LLVMFunctionType> {
+        /**
+         * Create a function type
+         *
+         * Argument count is automatically calculated from [paramTypes].
+         */
+        public fun type(returnType: LLVMType, paramTypes: List<LLVMType>, isVariadic: Boolean): LLVMFunctionType {
+            val types = paramTypes.map { it.llvmType }
+            val array = ArrayList(types).toTypedArray()
+
+            val ptr = PointerPointer(*array)
+
+            val type = LLVM.LLVMFunctionType(returnType.llvmType, ptr, paramTypes.size, isVariadic.toInt())
+
+            return LLVMFunctionType(type)
+        }
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerType.kt
@@ -1,5 +1,7 @@
 package dev.supergrecko.kllvm.core.type
 
+import dev.supergrecko.kllvm.contracts.ScalarTypeFactory
+import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMContextRef
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
@@ -12,7 +14,7 @@ public class LLVMIntegerType internal constructor(llvmType: LLVMTypeRef) : LLVMT
         return LLVM.LLVMGetIntTypeWidth(llvmType)
     }
 
-    companion object : TypeFactory<LLVMIntegerType, IntegerTypeKinds> {
+    public companion object : ScalarTypeFactory<LLVMIntegerType, IntegerTypeKinds> {
         /**
          * Create a type in the global context from a type kind
          *

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMType.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.kllvm.core.type
 
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
 
 /**
  * Higher level wrapper around LLVM Core's type module
@@ -8,6 +9,13 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
  * -[Documentation](https://llvm.org/doxygen/group__LLVMCCoreType.html)
  */
 public open class LLVMType internal constructor(internal val llvmType: LLVMTypeRef) {
+    /**
+     * Create a type of this exact type in the form of a Pointer
+     */
+    public fun asPointer(addressSpace: Int = 0): LLVMTypeRef {
+        return LLVM.LLVMPointerType(llvmType, addressSpace)
+    }
+
     /**
      * Enumerable to describe different LLVM floating-point number types
      *

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/TypeFactory.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/TypeFactory.kt
@@ -1,5 +1,0 @@
-package dev.supergrecko.kllvm.core.type
-
-internal interface TypeFactory<T, K> {
-    public fun type(kind: K): T
-}

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
@@ -1,0 +1,28 @@
+package dev.supergrecko.kllvm.core.type
+
+import dev.supergrecko.kllvm.utils.toBoolean
+import org.bytedeco.llvm.global.LLVM
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class LLVMFunctionTypeTest {
+    @Test
+    fun `creation of zero arg type works`() {
+        val ret = LLVMIntegerType.type(64)
+
+        val fn = LLVMFunctionType.type(ret, listOf(), false)
+
+        assertEquals(LLVM.LLVMCountParamTypes(fn.llvmType), 0)
+        assertEquals(LLVM.LLVMGetReturnType(fn.llvmType), ret.llvmType)
+    }
+
+    @Test
+    fun `variadic arguments work`() {
+        val ret = LLVMIntegerType.type(64)
+        val arg = LLVMFloatType.type(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
+
+        val fn = LLVMFunctionType.type(ret, listOf(arg), true)
+
+        assertEquals(LLVM.LLVMIsFunctionVarArg(fn.llvmType).toBoolean(), true)
+    }
+}

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
@@ -1,0 +1,16 @@
+package dev.supergrecko.kllvm.core.type
+
+import org.bytedeco.llvm.global.LLVM
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class LLVMTypeTest {
+    @Test
+    fun `test creation of pointer type`() {
+        val type = LLVMIntegerType.type(64)
+
+        val ptr = type.asPointer()
+
+        assertEquals(LLVM.LLVMGetTypeKind(ptr), LLVM.LLVMPointerTypeKind)
+    }
+}


### PR DESCRIPTION
This adds a few interfaces to group common logic like Disposables and Validatables

You are now able to create a LLVMFunctionType via the bindings