### PR TITLE
[api-refactor] Move type creation into LLVMType

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/contracts/TypeFactory.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/contracts/TypeFactory.kt
@@ -1,9 +1,0 @@
-package dev.supergrecko.kllvm.contracts
-
-internal interface TypeFactory<T>
-
-internal interface ScalarTypeFactory<T, K> : TypeFactory<T> {
-    public fun type(kind: K): T
-}
-
-internal interface CompositeTypeFactory<T> : TypeFactory<T>

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMContext.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMContext.kt
@@ -152,10 +152,10 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
      * @throws IllegalArgumentException If internal instance has been dropped.
      * @throws IllegalArgumentException If wanted size is less than 0 or larger than 2^23-1
      */
-    public fun integerType(size: Int): LLVMIntegerType {
+    public fun integerType(kind: LLVMType.IntegerTypeKinds, size: Int = 0): LLVMIntegerType {
         require(valid) { "This module has already been disposed."}
 
-        return LLVMIntegerType.type(llvmCtx, size)
+        return LLVMType.makeInteger(kind, size, llvmCtx)
     }
 
     /**
@@ -170,7 +170,7 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
     public fun floatType(kind: LLVMType.FloatTypeKinds): LLVMFloatType {
         require(valid) { "This module has already been disposed."}
 
-        return LLVMFloatType.type(llvmCtx, kind)
+        return LLVMType.makeFloat(kind, llvmCtx)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFloatType.kt
@@ -1,37 +1,5 @@
 package dev.supergrecko.kllvm.core.type
 
-import dev.supergrecko.kllvm.contracts.ScalarTypeFactory
-import org.bytedeco.llvm.LLVM.LLVMContextRef
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
-import org.bytedeco.llvm.global.LLVM
 
-public class LLVMFloatType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
-    public companion object : ScalarTypeFactory<LLVMFloatType, FloatTypeKinds> {
-        /**
-         * Create a float in the global context
-         *
-         * @throws IllegalArgumentException If internal instance has been dropped.
-         */
-        @JvmStatic
-        public override fun type(kind: FloatTypeKinds): LLVMFloatType = type(LLVM.LLVMGetGlobalContext(), kind)
-
-        /**
-         * Create a float in the given context
-         *
-         * @throws IllegalArgumentException If internal instance has been dropped.
-         */
-        @JvmStatic
-        public fun type(context: LLVMContextRef, kind: FloatTypeKinds): LLVMFloatType {
-            val type = when (kind) {
-                FloatTypeKinds.LLVM_HALF_TYPE -> LLVM.LLVMHalfTypeInContext(context)
-                FloatTypeKinds.LLVM_FLOAT_TYPE -> LLVM.LLVMFloatTypeInContext(context)
-                FloatTypeKinds.LLVM_DOUBLE_TYPE -> LLVM.LLVMDoubleTypeInContext(context)
-                FloatTypeKinds.LLVM_X86FP80_TYPE -> LLVM.LLVMX86FP80TypeInContext(context)
-                FloatTypeKinds.LLVM_FP128_TYPE -> LLVM.LLVMFP128TypeInContext(context)
-                FloatTypeKinds.LLVM_PPCFP128_TYPE -> LLVM.LLVMPPCFP128TypeInContext(context)
-            }
-
-            return LLVMFloatType(type)
-        }
-    }
-}
+public class LLVMFloatType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionType.kt
@@ -1,9 +1,6 @@
 package dev.supergrecko.kllvm.core.type
 
-import dev.supergrecko.kllvm.contracts.CompositeTypeFactory
 import dev.supergrecko.kllvm.utils.toBoolean
-import dev.supergrecko.kllvm.utils.toInt
-import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
@@ -41,22 +38,4 @@ public class LLVMFunctionType internal constructor(
 
     public fun getReturnType(): LLVMType = returnType
     public fun getParameters(): List<LLVMType> = paramTypes
-
-    public companion object : CompositeTypeFactory<LLVMFunctionType> {
-        /**
-         * Create a function type
-         *
-         * Argument count is automatically calculated from [paramTypes].
-         */
-        public fun type(returnType: LLVMType, paramTypes: List<LLVMType>, isVariadic: Boolean): LLVMFunctionType {
-            val types = paramTypes.map { it.llvmType }
-            val array = ArrayList(types).toTypedArray()
-
-            val ptr = PointerPointer(*array)
-
-            val type = LLVM.LLVMFunctionType(returnType.llvmType, ptr, paramTypes.size, isVariadic.toInt())
-
-            return LLVMFunctionType(type, returnType, paramTypes)
-        }
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerType.kt
@@ -1,8 +1,5 @@
 package dev.supergrecko.kllvm.core.type
 
-import dev.supergrecko.kllvm.contracts.ScalarTypeFactory
-import dev.supergrecko.kllvm.contracts.Validatable
-import org.bytedeco.llvm.LLVM.LLVMContextRef
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
@@ -12,80 +9,5 @@ public class LLVMIntegerType internal constructor(llvmType: LLVMTypeRef) : LLVMT
      */
     public fun typeWidth(): Int {
         return LLVM.LLVMGetIntTypeWidth(llvmType)
-    }
-
-    public companion object : ScalarTypeFactory<LLVMIntegerType, IntegerTypeKinds> {
-        /**
-         * Create a type in the global context from a type kind
-         *
-         * [LLVMType.IntegerTypeKinds.LLVM_INT_TYPE] cannot be used here as there is no size specified. Use the [LLVMIntegerType.type] overload
-         * with size.
-         *
-         * @throws IllegalArgumentException If internal instance has been dropped.
-         * @throws IllegalArgumentException If wanted [LLVMType.IntegerTypeKinds] is [LLVMType.IntegerTypeKinds.LLVM_INT_TYPE]
-         */
-        @JvmStatic
-        public override fun type(kind: IntegerTypeKinds): LLVMIntegerType {
-            require(kind != IntegerTypeKinds.LLVM_INT_TYPE) { "Cannot summon IntegerTypeKinds.LLVM_INT_TYPE with unspecified size." }
-
-            return type(LLVM.LLVMGetGlobalContext(), kind, 0)
-        }
-
-        /**
-         * Create a type in the global context from a given size.
-         *
-         * @throws IllegalArgumentException If internal instance has been dropped.
-         * @throws IllegalArgumentException If wanted size is less than 0 or larger than 2^23-1
-         */
-        @JvmStatic
-        public fun type(size: Int): LLVMIntegerType = type(LLVM.LLVMGetGlobalContext(), size)
-
-        /**
-         * Create a type in a context from a kind. [size] is only used for [LLVMType.IntegerTypeKinds.LLVM_INT_TYPE].
-         *
-         * @throws IllegalArgumentException If internal instance has been dropped.
-         * @throws IllegalArgumentException If wanted size is less than 0 or larger than 2^23-1
-         */
-        @JvmStatic
-        public fun type(context: LLVMContextRef, kind: IntegerTypeKinds, size: Int = 0): LLVMIntegerType {
-            require(!context.isNull)
-
-            val type = when (kind) {
-                IntegerTypeKinds.LLVM_I1_TYPE -> LLVM.LLVMInt1TypeInContext(context)
-                IntegerTypeKinds.LLVM_I8_TYPE -> LLVM.LLVMInt8TypeInContext(context)
-                IntegerTypeKinds.LLVM_I16_TYPE -> LLVM.LLVMInt16TypeInContext(context)
-                IntegerTypeKinds.LLVM_I32_TYPE -> LLVM.LLVMInt32TypeInContext(context)
-                IntegerTypeKinds.LLVM_I64_TYPE -> LLVM.LLVMInt64TypeInContext(context)
-                IntegerTypeKinds.LLVM_I128_TYPE -> LLVM.LLVMInt128TypeInContext(context)
-                IntegerTypeKinds.LLVM_INT_TYPE -> {
-                    require(size in 1..8388606) { "LLVM only supports integers of 2^23-1 bits size" }
-
-                    LLVM.LLVMIntTypeInContext(context, size)
-                }
-            }
-
-            return LLVMIntegerType(type)
-        }
-
-        /**
-         * Create a type in a context and a known size.
-         *
-         * @throws IllegalArgumentException If internal instance has been dropped.
-         * @throws IllegalArgumentException If wanted size is less than 0 or larger than 2^23-1
-         */
-        @JvmStatic
-        public fun type(context: LLVMContextRef, size: Int): LLVMIntegerType {
-            val kind = when (size) {
-                1 -> IntegerTypeKinds.LLVM_I1_TYPE
-                8 -> IntegerTypeKinds.LLVM_I8_TYPE
-                16 -> IntegerTypeKinds.LLVM_I16_TYPE
-                32-> IntegerTypeKinds.LLVM_I32_TYPE
-                64 -> IntegerTypeKinds.LLVM_I64_TYPE
-                128 -> IntegerTypeKinds.LLVM_I128_TYPE
-                else -> IntegerTypeKinds.LLVM_INT_TYPE
-            }
-
-            return type(context, kind, size)
-        }
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/LLVMContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/LLVMContextTest.kt
@@ -1,7 +1,6 @@
 package dev.supergrecko.kllvm.core
 
 import dev.supergrecko.kllvm.utils.runAll
-import org.bytedeco.llvm.global.LLVM
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -35,16 +34,6 @@ class LLVMContextTest {
         runAll(true, false) {
             ctx.setDiscardValueNames(it)
             assertEquals(it, ctx.shouldDiscardValueNames())
-        }
-    }
-
-    @Test
-    fun `get integer types from llvm`() {
-        val ctx = LLVMContext.create()
-
-        runAll(1, 6, 16, 32, 64, 8237, 64362) {
-            val type = ctx.integerType(it)
-            assertEquals(it, type.typeWidth())
         }
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
@@ -8,9 +8,8 @@ import kotlin.test.assertEquals
 class LLVMFunctionTypeTest {
     @Test
     fun `creation of zero arg type works`() {
-        val ret = LLVMIntegerType.type(64)
-
-        val fn = LLVMFunctionType.type(ret, listOf(), false)
+        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
+        val fn = LLVMType.makeFunction(ret, listOf(), false)
 
         assertEquals(fn.getParameterCount(), 0)
         assertEquals(fn.getReturnType().llvmType, ret.llvmType)
@@ -18,30 +17,27 @@ class LLVMFunctionTypeTest {
 
     @Test
     fun `variadic arguments work`() {
-        val ret = LLVMIntegerType.type(64)
-        val arg = LLVMFloatType.type(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
-
-        val fn = LLVMFunctionType.type(ret, listOf(arg), true)
+        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
+        val arg = LLVMType.makeFloat(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
+        val fn = LLVMType.makeFunction(ret, listOf(arg), true)
 
         assertEquals(fn.isVariadic(), true)
     }
 
     @Test
     fun `test variadic wrapper works`() {
-        val ret = LLVMIntegerType.type(64)
-        val arg = LLVMFloatType.type(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
-
-        val fn = LLVMFunctionType.type(ret, listOf(arg), true)
+        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
+        val arg = LLVMType.makeFloat(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
+        val fn = LLVMType.makeFunction(ret, listOf(arg), true)
 
         assertEquals(LLVM.LLVMIsFunctionVarArg(fn.llvmType).toBoolean(), fn.isVariadic())
     }
 
     @Test
     fun `test parameter count wrapper works`() {
-        val ret = LLVMIntegerType.type(64)
-        val arg = LLVMFloatType.type(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
-
-        val fn = LLVMFunctionType.type(ret, listOf(arg), true)
+        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
+        val arg = LLVMType.makeFloat(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
+        val fn = LLVMType.makeFunction(ret, listOf(arg), true)
 
         assertEquals(LLVM.LLVMCountParamTypes(fn.llvmType), fn.getParameterCount())
     }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerTypeTest.kt
@@ -13,8 +13,8 @@ class LLVMIntegerTypeTest {
         val ctx = LLVMContext.create()
 
         runAll(1, 8, 16, 32, 64, 128) {
-            val contextType = ctx.integerType(it)
-            val globalType = LLVMIntegerType.type(it)
+            val contextType = ctx.integerType(LLVMType.IntegerTypeKinds.LLVM_INT_TYPE, it)
+            val globalType = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_INT_TYPE, it)
 
             assertEquals(contextType.typeWidth(), globalType.typeWidth())
         }
@@ -25,7 +25,7 @@ class LLVMIntegerTypeTest {
         val ctx = LLVMContext.create()
 
         runAll(*LLVMType.IntegerTypeKinds.values()) {
-            val type = LLVMIntegerType.type(ctx.llvmCtx, it, 100)
+            val type = LLVMType.makeInteger(it, 1024, ctx.llvmCtx)
 
             assertTrue { !type.llvmType.isNull }
         }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class LLVMTypeTest {
     @Test
     fun `test creation of pointer type`() {
-        val type = LLVMIntegerType.type(64)
+        val type = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
 
         val ptr = type.asPointer()
 


### PR DESCRIPTION
Moving all type creation into LLVMType makes everything a lot easier to access.