### PR TITLE
[api] Move LLVMTypeKind into its own file

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMContext.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMContext.kt
@@ -2,9 +2,7 @@ package dev.supergrecko.kllvm.core
 
 import dev.supergrecko.kllvm.contracts.Disposable
 import dev.supergrecko.kllvm.contracts.Validatable
-import dev.supergrecko.kllvm.core.type.LLVMFloatType
-import dev.supergrecko.kllvm.core.type.LLVMIntegerType
-import dev.supergrecko.kllvm.core.type.LLVMType
+import dev.supergrecko.kllvm.core.type.*
 import dev.supergrecko.kllvm.utils.toBoolean
 import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.javacpp.Pointer
@@ -152,7 +150,7 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
      * @throws IllegalArgumentException If internal instance has been dropped.
      * @throws IllegalArgumentException If wanted size is less than 0 or larger than 2^23-1
      */
-    public fun integerType(kind: LLVMType.IntegerTypeKinds, size: Int = 0): LLVMIntegerType {
+    public fun integerType(kind: LLVMTypeKind.Integer, size: Int = 0): LLVMIntegerType {
         require(valid) { "This module has already been disposed."}
 
         return LLVMType.makeInteger(kind, size, llvmCtx)
@@ -167,7 +165,7 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
      *
      * @throws IllegalArgumentException If internal instance has been dropped
      */
-    public fun floatType(kind: LLVMType.FloatTypeKinds): LLVMFloatType {
+    public fun floatType(kind: LLVMTypeKind.Float): LLVMFloatType {
         require(valid) { "This module has already been disposed."}
 
         return LLVMType.makeFloat(kind, llvmCtx)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMType.kt
@@ -19,46 +19,6 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
         return LLVM.LLVMPointerType(llvmType, addressSpace)
     }
 
-    /**
-     * Enumerable to describe different LLVM floating-point number types
-     *
-     * @property LLVM_HALF_TYPE LLVM 16-bit float
-     * @property LLVM_FLOAT_TYPE LLVM 32-bit float
-     * @property LLVM_DOUBLE_TYPE LLVM 64-bit float
-     * @property LLVM_X86FP80_TYPE LLVM 80-bit float (x87) https://en.wikipedia.org/wiki/X87
-     * @property LLVM_FP128_TYPE LLVM 128-bit float https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format#IEEE_754_quadruple-precision_binary_floating-point_format:_binary128
-     * @property LLVM_PPCFP128_TYPE LLVM 128-bit float (2x 64-bit)
-     */
-    public enum class FloatTypeKinds {
-        LLVM_HALF_TYPE,
-        LLVM_FLOAT_TYPE,
-        LLVM_DOUBLE_TYPE,
-        LLVM_X86FP80_TYPE,
-        LLVM_FP128_TYPE,
-        LLVM_PPCFP128_TYPE
-    }
-
-    /**
-     * Enumerable to describe different LLVM integer types
-     *
-     * @property LLVM_I1_TYPE LLVM 1-bit integer
-     * @property LLVM_I8_TYPE LLVM 8-bit integer
-     * @property LLVM_I16_TYPE LLVM 16-bit integer
-     * @property LLVM_I32_TYPE LLVM 32-bit integer
-     * @property LLVM_I64_TYPE LLVM 64-bit integer
-     * @property LLVM_I128_TYPE LLVM 128-bit integer
-     * @property LLVM_INT_TYPE Arbitrarily large LLVM integer
-     */
-    public enum class IntegerTypeKinds {
-        LLVM_I1_TYPE,
-        LLVM_I8_TYPE,
-        LLVM_I16_TYPE,
-        LLVM_I32_TYPE,
-        LLVM_I64_TYPE,
-        LLVM_I128_TYPE,
-        LLVM_INT_TYPE
-    }
-
     companion object {
         /**
          * Create a type in a context and a known size.
@@ -70,15 +30,15 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
          * @throws IllegalArgumentException If wanted size is less than 0 or larger than 2^23-1
          */
         @JvmStatic
-        public fun makeInteger(kind: IntegerTypeKinds, size: Int = 0, context: LLVMContextRef = LLVM.LLVMGetGlobalContext()): LLVMIntegerType {
+        public fun makeInteger(kind: LLVMTypeKind.Integer, size: Int = 0, context: LLVMContextRef = LLVM.LLVMGetGlobalContext()): LLVMIntegerType {
             val type = when (kind) {
-                IntegerTypeKinds.LLVM_I1_TYPE -> LLVM.LLVMInt1TypeInContext(context)
-                IntegerTypeKinds.LLVM_I8_TYPE -> LLVM.LLVMInt8TypeInContext(context)
-                IntegerTypeKinds.LLVM_I16_TYPE -> LLVM.LLVMInt16TypeInContext(context)
-                IntegerTypeKinds.LLVM_I32_TYPE -> LLVM.LLVMInt32TypeInContext(context)
-                IntegerTypeKinds.LLVM_I64_TYPE -> LLVM.LLVMInt64TypeInContext(context)
-                IntegerTypeKinds.LLVM_I128_TYPE -> LLVM.LLVMInt128TypeInContext(context)
-                IntegerTypeKinds.LLVM_INT_TYPE -> {
+                LLVMTypeKind.Integer.LLVM_I1_TYPE -> LLVM.LLVMInt1TypeInContext(context)
+                LLVMTypeKind.Integer.LLVM_I8_TYPE -> LLVM.LLVMInt8TypeInContext(context)
+                LLVMTypeKind.Integer.LLVM_I16_TYPE -> LLVM.LLVMInt16TypeInContext(context)
+                LLVMTypeKind.Integer.LLVM_I32_TYPE -> LLVM.LLVMInt32TypeInContext(context)
+                LLVMTypeKind.Integer.LLVM_I64_TYPE -> LLVM.LLVMInt64TypeInContext(context)
+                LLVMTypeKind.Integer.LLVM_I128_TYPE -> LLVM.LLVMInt128TypeInContext(context)
+                LLVMTypeKind.Integer.LLVM_INT_TYPE -> {
                     require(size in 1..8388606) { "LLVM only supports integers of 2^23-1 bits size" }
 
                     LLVM.LLVMIntTypeInContext(context, size)
@@ -95,14 +55,14 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
          * @param context The context to use, default to global
          */
         @JvmStatic
-        public fun makeFloat(kind: FloatTypeKinds, context: LLVMContextRef = LLVM.LLVMGetGlobalContext()): LLVMFloatType {
+        public fun makeFloat(kind: LLVMTypeKind.Float, context: LLVMContextRef = LLVM.LLVMGetGlobalContext()): LLVMFloatType {
             val type = when (kind) {
-                FloatTypeKinds.LLVM_HALF_TYPE -> LLVM.LLVMHalfTypeInContext(context)
-                FloatTypeKinds.LLVM_FLOAT_TYPE -> LLVM.LLVMFloatTypeInContext(context)
-                FloatTypeKinds.LLVM_DOUBLE_TYPE -> LLVM.LLVMDoubleTypeInContext(context)
-                FloatTypeKinds.LLVM_X86FP80_TYPE -> LLVM.LLVMX86FP80TypeInContext(context)
-                FloatTypeKinds.LLVM_FP128_TYPE -> LLVM.LLVMFP128TypeInContext(context)
-                FloatTypeKinds.LLVM_PPCFP128_TYPE -> LLVM.LLVMPPCFP128TypeInContext(context)
+                LLVMTypeKind.Float.LLVM_HALF_TYPE -> LLVM.LLVMHalfTypeInContext(context)
+                LLVMTypeKind.Float.LLVM_FLOAT_TYPE -> LLVM.LLVMFloatTypeInContext(context)
+                LLVMTypeKind.Float.LLVM_DOUBLE_TYPE -> LLVM.LLVMDoubleTypeInContext(context)
+                LLVMTypeKind.Float.LLVM_X86FP80_TYPE -> LLVM.LLVMX86FP80TypeInContext(context)
+                LLVMTypeKind.Float.LLVM_FP128_TYPE -> LLVM.LLVMFP128TypeInContext(context)
+                LLVMTypeKind.Float.LLVM_PPCFP128_TYPE -> LLVM.LLVMPPCFP128TypeInContext(context)
             }
 
             return LLVMFloatType(type)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeKind.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeKind.kt
@@ -1,0 +1,58 @@
+package dev.supergrecko.kllvm.core.type
+
+/**
+ * Enum listing all LLVM Type Kinds.
+ *
+ * @property LLVM_X86MMX_TYPE he x86_mmx type represents a value held in an MMX register on an x86 machine
+ */
+public enum class LLVMTypeKind {
+    LLVM_LABEL_TYPE,
+    LLVM_FUNCTION_TYPE,
+    LLVM_STRUCT_TYPE,
+    LLVM_ARRAY_TYPE,
+    LLVM_POINTER_TYPE,
+    LLVM_VECTOR_TYPE,
+    LLVM_METADATA_TYPE,
+    LLVM_X86MMX_TYPE,
+    LLVM_TOKEN_TYPE;
+
+    /**
+     * Enumerable to describe different LLVM floating-point number types
+     *
+     * @property LLVM_HALF_TYPE LLVM 16-bit float
+     * @property LLVM_FLOAT_TYPE LLVM 32-bit float
+     * @property LLVM_DOUBLE_TYPE LLVM 64-bit float
+     * @property LLVM_X86FP80_TYPE LLVM 80-bit float (x87) https://en.wikipedia.org/wiki/X87
+     * @property LLVM_FP128_TYPE LLVM 128-bit float https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format#IEEE_754_quadruple-precision_binary_floating-point_format:_binary128
+     * @property LLVM_PPCFP128_TYPE LLVM 128-bit float (2x 64-bit)
+     */
+    enum class Float {
+        LLVM_HALF_TYPE,
+        LLVM_FLOAT_TYPE,
+        LLVM_DOUBLE_TYPE,
+        LLVM_X86FP80_TYPE,
+        LLVM_FP128_TYPE,
+        LLVM_PPCFP128_TYPE
+    }
+
+    /**
+     * Enumerable to describe different LLVM integer types
+     *
+     * @property LLVM_I1_TYPE LLVM 1-bit integer
+     * @property LLVM_I8_TYPE LLVM 8-bit integer
+     * @property LLVM_I16_TYPE LLVM 16-bit integer
+     * @property LLVM_I32_TYPE LLVM 32-bit integer
+     * @property LLVM_I64_TYPE LLVM 64-bit integer
+     * @property LLVM_I128_TYPE LLVM 128-bit integer
+     * @property LLVM_INT_TYPE Arbitrarily large LLVM integer
+     */
+    public enum class Integer {
+        LLVM_I1_TYPE,
+        LLVM_I8_TYPE,
+        LLVM_I16_TYPE,
+        LLVM_I32_TYPE,
+        LLVM_I64_TYPE,
+        LLVM_I128_TYPE,
+        LLVM_INT_TYPE
+    }
+}

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFloatTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFloatTypeTest.kt
@@ -10,7 +10,7 @@ class LLVMFloatTypeTest {
     fun `it actually grabs types instead of null pointers`() {
         val ctx = LLVMContext.create()
 
-        runAll(*LLVMType.FloatTypeKinds.values()) {
+        runAll(*LLVMTypeKind.Float.values()) {
             val type = ctx.floatType(it)
 
             assertTrue { !type.llvmType.isNull }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 class LLVMFunctionTypeTest {
     @Test
     fun `creation of zero arg type works`() {
-        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
+        val ret = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I64_TYPE)
         val fn = LLVMType.makeFunction(ret, listOf(), false)
 
         assertEquals(fn.getParameterCount(), 0)
@@ -17,8 +17,8 @@ class LLVMFunctionTypeTest {
 
     @Test
     fun `variadic arguments work`() {
-        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
-        val arg = LLVMType.makeFloat(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
+        val ret = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I64_TYPE)
+        val arg = LLVMType.makeFloat(LLVMTypeKind.Float.LLVM_FLOAT_TYPE)
         val fn = LLVMType.makeFunction(ret, listOf(arg), true)
 
         assertEquals(fn.isVariadic(), true)
@@ -26,8 +26,8 @@ class LLVMFunctionTypeTest {
 
     @Test
     fun `test variadic wrapper works`() {
-        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
-        val arg = LLVMType.makeFloat(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
+        val ret = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I64_TYPE)
+        val arg = LLVMType.makeFloat(LLVMTypeKind.Float.LLVM_FLOAT_TYPE)
         val fn = LLVMType.makeFunction(ret, listOf(arg), true)
 
         assertEquals(LLVM.LLVMIsFunctionVarArg(fn.llvmType).toBoolean(), fn.isVariadic())
@@ -35,8 +35,8 @@ class LLVMFunctionTypeTest {
 
     @Test
     fun `test parameter count wrapper works`() {
-        val ret = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
-        val arg = LLVMType.makeFloat(LLVMType.FloatTypeKinds.LLVM_FLOAT_TYPE)
+        val ret = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I64_TYPE)
+        val arg = LLVMType.makeFloat(LLVMTypeKind.Float.LLVM_FLOAT_TYPE)
         val fn = LLVMType.makeFunction(ret, listOf(arg), true)
 
         assertEquals(LLVM.LLVMCountParamTypes(fn.llvmType), fn.getParameterCount())

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerTypeTest.kt
@@ -2,7 +2,6 @@ package dev.supergrecko.kllvm.core.type
 
 import dev.supergrecko.kllvm.core.LLVMContext
 import dev.supergrecko.kllvm.utils.runAll
-import org.bytedeco.llvm.global.LLVM
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -13,8 +12,8 @@ class LLVMIntegerTypeTest {
         val ctx = LLVMContext.create()
 
         runAll(1, 8, 16, 32, 64, 128) {
-            val contextType = ctx.integerType(LLVMType.IntegerTypeKinds.LLVM_INT_TYPE, it)
-            val globalType = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_INT_TYPE, it)
+            val contextType = ctx.integerType(LLVMTypeKind.Integer.LLVM_INT_TYPE, it)
+            val globalType = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_INT_TYPE, it)
 
             assertEquals(contextType.typeWidth(), globalType.typeWidth())
         }
@@ -24,7 +23,7 @@ class LLVMIntegerTypeTest {
     fun `it actually grabs types instead of null pointers`() {
         val ctx = LLVMContext.create()
 
-        runAll(*LLVMType.IntegerTypeKinds.values()) {
+        runAll(*LLVMTypeKind.Integer.values()) {
             val type = LLVMType.makeInteger(it, 1024, ctx.llvmCtx)
 
             assertTrue { !type.llvmType.isNull }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class LLVMTypeTest {
     @Test
     fun `test creation of pointer type`() {
-        val type = LLVMType.makeInteger(LLVMType.IntegerTypeKinds.LLVM_I64_TYPE)
+        val type = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I64_TYPE)
 
         val ptr = type.asPointer()
 


### PR DESCRIPTION
Moves the enum declarations for the LLVM type kinds into its own file