### PR TITLE
[api] Add asT and intoT for LLVMType

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMArrayType.kt
@@ -10,10 +10,8 @@ public class LLVMArrayType internal constructor(llvmType: LLVMTypeRef) : LLVMTyp
         return LLVM.LLVMGetArrayLength(llvmType)
     }
 
-    /**
-     * TODO: Learn how to test this
-     */
     public fun getSubtypes(): List<LLVMType> {
+        // TODO: Learn how to test this
         val dest = PointerPointer<LLVMTypeRef>(getLength().toLong())
         LLVM.LLVMGetSubtypes(llvmType, dest)
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionType.kt
@@ -6,11 +6,6 @@ import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-/**
- * Wrapper around LLVM Function Types
- *
- * @property llvmType Internal [LLVMTypeRef] reference
- */
 public class LLVMFunctionType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
     public fun isVariadic(): Boolean {
         return LLVM.LLVMIsFunctionVarArg(llvmType).toBoolean()
@@ -26,7 +21,7 @@ public class LLVMFunctionType internal constructor(llvmType: LLVMTypeRef) : LLVM
         return LLVMType(type)
     }
 
-    public fun getParameters(): List<LLVMType> {
+    public fun getParameterTypes(): List<LLVMType> {
         val dest = PointerPointer<LLVMTypeRef>(getParameterCount().toLong())
         LLVM.LLVMGetParamTypes(llvmType, dest)
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMIntegerType.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.global.LLVM
 
 public class LLVMIntegerType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
     /**
-     * Get the amount of bits this type can hold
+     * Returns the amount of bits this integer type can hold
      */
     public fun typeWidth(): Int {
         return LLVM.LLVMGetIntTypeWidth(llvmType)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMPointerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMPointerType.kt
@@ -14,10 +14,8 @@ public class LLVMPointerType internal constructor(llvmType: LLVMTypeRef) : LLVMT
         return LLVM.LLVMGetNumContainedTypes(llvmType)
     }
 
-    /**
-     * TODO: Learn how to test this
-     */
     public fun getSubtypes(): List<LLVMType> {
+        // TODO: Learn how to test this
         val dest = PointerPointer<LLVMTypeRef>(getContainedTypes().toLong())
         LLVM.LLVMGetSubtypes(llvmType, dest)
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMType.kt
@@ -12,17 +12,58 @@ import org.bytedeco.llvm.global.LLVM
  * -[Documentation](https://llvm.org/doxygen/group__LLVMCCoreType.html)
  */
 public open class LLVMType internal constructor(internal val llvmType: LLVMTypeRef) {
-    public fun asPointer(addressSpace: Int = 0): LLVMPointerType {
+    /**
+     * Feed this type into a [LLVMPointerType]
+     */
+    public fun intoPointer(addressSpace: Int = 0): LLVMPointerType {
         require(addressSpace >= 0) { "Cannot use negative address space as it would cause integer underflow" }
         val ptr = LLVM.LLVMPointerType(llvmType, addressSpace)
 
         return LLVMPointerType(ptr)
     }
 
+    /**
+     * Feed this type into a [LLVMArrayType]
+     */
+    public fun intoArray(): LLVMArrayType {
+        return LLVMArrayType(llvmType)
+    }
+
+    /**
+     * Feed this type into a [LLVMVectorType]
+     */
+    public fun intoVector(): LLVMVectorType {
+        return LLVMVectorType(llvmType)
+    }
+
+    /**
+     * Cast to [LLVMPointerType]
+     */
+    public fun asPointer(): LLVMPointerType = LLVMPointerType(llvmType)
+
+    /**
+     * Cast to [LLVMIntegerType]
+     */
     public fun asInteger(): LLVMIntegerType = LLVMIntegerType(llvmType)
+
+    /**
+     * Cast to [LLVMFunctionType]
+     */
     public fun asFunction(): LLVMFunctionType = LLVMFunctionType(llvmType)
+
+    /**
+     * Cast to [LLVMStructureType]
+     */
     public fun asStruct(): LLVMStructureType = LLVMStructureType(llvmType)
+
+    /**
+     * Cast to [LLVMArrayType]
+     */
     public fun asArray(): LLVMArrayType = LLVMArrayType(llvmType)
+
+    /**
+     * Cast to [LLVMVectorType]
+     */
     public fun asVector(): LLVMVectorType = LLVMVectorType(llvmType)
 
     companion object {

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMVectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/type/LLVMVectorType.kt
@@ -10,10 +10,8 @@ public class LLVMVectorType internal constructor(llvmType: LLVMTypeRef) : LLVMTy
         return LLVM.LLVMGetVectorSize(llvmType)
     }
 
-    /**
-     * TODO: Learn how to test this
-     */
     public fun getSubtypes(): List<LLVMType> {
+        // TODO: Learn how to test this
         val dest = PointerPointer<LLVMTypeRef>(getSize().toLong())
         LLVM.LLVMGetSubtypes(llvmType, dest)
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMFunctionTypeTest.kt
@@ -49,7 +49,7 @@ class LLVMFunctionTypeTest {
         val args = listOf(LLVMType.make(LLVMTypeKind.LLVM_FLOAT_TYPE))
         val fn = LLVMType.makeFunction(ret, args, true)
 
-        val params = fn.getParameters()
+        val params = fn.getParameterTypes()
 
         for (i in args.indices) {
             val x = params[i].llvmType

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMPointerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMPointerTypeTest.kt
@@ -7,7 +7,7 @@ class LLVMPointerTypeTest {
     @Test
     fun `underlying type matches`() {
         val type = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I32_TYPE)
-        val ptr = type.asPointer()
+        val ptr = type.intoPointer()
 
         assertEquals(type.llvmType, ptr.getElementType().llvmType)
     }
@@ -15,7 +15,7 @@ class LLVMPointerTypeTest {
     @Test
     fun `address space matches`() {
         val type = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I32_TYPE)
-        val ptr = type.asPointer(100)
+        val ptr = type.intoPointer(100)
 
         assertEquals(100, ptr.getAddressSpace())
     }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/type/LLVMTypeTest.kt
@@ -10,7 +10,7 @@ class LLVMTypeTest {
     fun `test creation of pointer type`() {
         val type = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I64_TYPE)
 
-        val ptr = type.asPointer()
+        val ptr = type.intoPointer()
 
         assertEquals(LLVM.LLVMGetTypeKind(ptr.llvmType), LLVM.LLVMPointerTypeKind)
     }
@@ -26,7 +26,7 @@ class LLVMTypeTest {
     @Test
     fun `casting into other type works when expected to`() {
         val type = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I32_TYPE)
-        val ptr = type.asPointer()
+        val ptr = type.intoPointer()
         val underlying = ptr.getElementType()
 
         assertEquals(type.llvmType, underlying.asInteger().llvmType)
@@ -37,7 +37,7 @@ class LLVMTypeTest {
         // This behavior is documented at LLVMType. There is no way
         // to guarantee that the underlying type is valid or invalid
         val type = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I32_TYPE)
-        val ptr = type.asPointer()
+        val ptr = type.intoPointer()
         val underlying = ptr.getElementType()
 
         assertEquals(type.llvmType, underlying.asFunction().llvmType)


### PR DESCRIPTION
Because there is no way to tell the Kotlin type system what type a LLVMTypeRef actually is we have our wrappers around various LLVM types. We therefore need an explicit way to cast LLVMType to any its child classes.