### PR TITLE
[refactor] Move LLVMType into /core and fix naming

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMContext.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMContext.kt
@@ -2,7 +2,7 @@ package dev.supergrecko.kllvm.core
 
 import dev.supergrecko.kllvm.contracts.Disposable
 import dev.supergrecko.kllvm.contracts.Validatable
-import dev.supergrecko.kllvm.core.type.*
+import dev.supergrecko.kllvm.core.types.*
 import dev.supergrecko.kllvm.utils.toBoolean
 import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.javacpp.Pointer
@@ -33,7 +33,7 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
      * }
      *
      * @param handler The diagnostic handler to use
-     * @param diagnosticContext The diagnostic context. Pointer type: DiagnosticContext*
+     * @param diagnosticContext The diagnostic context. Pointer types: DiagnosticContext*
      *
      * - [LLVMContextSetDiagnosticHandler](https://llvm.org/doxygen/group__LLVMCCoreContext.html#gacbfc704565962bf71eaaa549a9be570f)
      *
@@ -81,7 +81,7 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
      * Register a yield callback with the given context.
      *
      * @param callback Callback to register. C++ Type: void (*)(LLVMContext *Context, void *OpaqueHandle)
-     * @param opaqueHandle Pointer type: void*
+     * @param opaqueHandle Pointer types: void*
      *
      * - [LLVMContextSetYieldCallback](https://llvm.org/doxygen/group__LLVMCCoreContext.html#gabdcc4e421199e9e7bb5e0cd449468731)
      *
@@ -137,15 +137,15 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
     }
 
     /**
-     * Obtain an integer type from the context with specified bit width.
+     * Obtain an integer types from the context with specified bit width.
      *
      * These are the integer types described in the Language manual. The size passed in must satisfy the constraints
-     * required in [LLVMIntegerType.type].
+     * required in [LLVMIntegerType.types].
      *
      * There are special cases for all built-in LLVM Integer types (1, 8, 16, 32, 64, 128) which will be used if the
      * passed [size] is equal to any of these, otherwise [LLVM.LLVMIntTypeInContext] will be used.
      *
-     * - https://llvm.org/docs/LangRef.html#integer-type
+     * - https://llvm.org/docs/LangRef.html#integer-types
      *
      * @throws IllegalArgumentException If internal instance has been dropped.
      * @throws IllegalArgumentException If wanted size is less than 0 or larger than 2^23-1
@@ -157,7 +157,7 @@ public class LLVMContext internal constructor(internal val llvmCtx: LLVMContextR
     }
 
     /**
-     * Obtain a floating-point number type from the context
+     * Obtain a floating-point number types from the context
      *
      * These are the floating-point numbers described in the language manual.
      *

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMType.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core
 
+import dev.supergrecko.kllvm.core.types.*
 import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMContextRef
@@ -7,13 +8,13 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 /**
- * Higher level wrapper around LLVM Core's type module
+ * Higher level wrapper around LLVM Core's types module
  *
  * -[Documentation](https://llvm.org/doxygen/group__LLVMCCoreType.html)
  */
 public open class LLVMType internal constructor(internal val llvmType: LLVMTypeRef) {
     /**
-     * Feed this type into a [LLVMPointerType]
+     * Feed this types into a [LLVMPointerType]
      */
     public fun intoPointer(addressSpace: Int = 0): LLVMPointerType {
         require(addressSpace >= 0) { "Cannot use negative address space as it would cause integer underflow" }
@@ -23,14 +24,14 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
     }
 
     /**
-     * Feed this type into a [LLVMArrayType]
+     * Feed this types into a [LLVMArrayType]
      */
     public fun intoArray(): LLVMArrayType {
         return LLVMArrayType(llvmType)
     }
 
     /**
-     * Feed this type into a [LLVMVectorType]
+     * Feed this types into a [LLVMVectorType]
      */
     public fun intoVector(): LLVMVectorType {
         return LLVMVectorType(llvmType)
@@ -68,7 +69,7 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
 
     companion object {
         /**
-         * Create a type in a context and a known size.
+         * Create a types in a context and a known size.
          *
          * @param kind Integer kind to create
          * @param size Context size for [LLVMType.IntegerTypeKinds.LLVM_INT_TYPE]
@@ -96,9 +97,9 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
         }
 
         /**
-         * Create a float type in the given context
+         * Create a float types in the given context
          *
-         * @param kind Float type to create
+         * @param kind Float types to create
          * @param context The context to use, default to global
          */
         @JvmStatic
@@ -121,11 +122,11 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
         }
 
         /**
-         * Create a function type
+         * Create a function types
          *
          * Argument count is automatically calculated from [paramTypes].
          *
-         * @param returnType Expected return type
+         * @param returnType Expected return types
          * @param paramTypes List of parameter types
          * @param isVariadic Is the function variadic?
          */
@@ -141,7 +142,7 @@ public open class LLVMType internal constructor(internal val llvmType: LLVMTypeR
         }
 
         /**
-         * Create a structure type
+         * Create a structure types
          *
          * This method creates different kinds of structure types depending on whether [name] is passed or not.
          * If name is passed, an opaque struct is created, otherwise a regular struct is created inside the given

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/LLVMValue.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core
+
+import org.bytedeco.llvm.LLVM.LLVMValueRef
+
+public class LLVMValue internal constructor(internal val llvmValue: LLVMValueRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMArrayType.kt
@@ -1,22 +1,19 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.iterateIntoType
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class LLVMPointerType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
-    public fun getAddressSpace(): Int {
-        return LLVM.LLVMGetPointerAddressSpace(llvmType)
-    }
-
-    public fun getContainedTypes(): Int {
-        return LLVM.LLVMGetNumContainedTypes(llvmType)
+public class LLVMArrayType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun getLength(): Int {
+        return LLVM.LLVMGetArrayLength(llvmType)
     }
 
     public fun getSubtypes(): List<LLVMType> {
         // TODO: Learn how to test this
-        val dest = PointerPointer<LLVMTypeRef>(getContainedTypes().toLong())
+        val dest = PointerPointer<LLVMTypeRef>(getLength().toLong())
         LLVM.LLVMGetSubtypes(llvmType, dest)
 
         return dest.iterateIntoType { LLVMType(it) }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMFunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMFunctionType.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.iterateIntoType
 import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.javacpp.PointerPointer

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerType.kt
@@ -1,11 +1,12 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class LLVMIntegerType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
     /**
-     * Returns the amount of bits this integer type can hold
+     * Returns the amount of bits this integer types can hold
      */
     public fun typeWidth(): Int {
         return LLVM.LLVMGetIntTypeWidth(llvmType)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMPointerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMPointerType.kt
@@ -1,18 +1,23 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.iterateIntoType
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class LLVMVectorType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
-    public fun getSize(): Int {
-        return LLVM.LLVMGetVectorSize(llvmType)
+public class LLVMPointerType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun getAddressSpace(): Int {
+        return LLVM.LLVMGetPointerAddressSpace(llvmType)
+    }
+
+    public fun getContainedTypes(): Int {
+        return LLVM.LLVMGetNumContainedTypes(llvmType)
     }
 
     public fun getSubtypes(): List<LLVMType> {
         // TODO: Learn how to test this
-        val dest = PointerPointer<LLVMTypeRef>(getSize().toLong())
+        val dest = PointerPointer<LLVMTypeRef>(getContainedTypes().toLong())
         LLVM.LLVMGetSubtypes(llvmType, dest)
 
         return dest.iterateIntoType { LLVMType(it) }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMStructureType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMStructureType.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.iterateIntoType
 import dev.supergrecko.kllvm.utils.toBoolean
 import dev.supergrecko.kllvm.utils.toInt

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeKind.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeKind.kt
@@ -1,9 +1,9 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
 /**
  * Enum listing all LLVM Type Kinds.
  *
- * @property LLVM_X86MMX_TYPE he x86_mmx type represents a value held in an MMX register on an x86 machine
+ * @property LLVM_X86MMX_TYPE he x86_mmx types represents a value held in an MMX register on an x86 machine
  * @property LLVM_HALF_TYPE LLVM 16-bit float
  * @property LLVM_FLOAT_TYPE LLVM 32-bit float
  * @property LLVM_DOUBLE_TYPE LLVM 64-bit float

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMVectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LLVMVectorType.kt
@@ -1,18 +1,19 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.iterateIntoType
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class LLVMArrayType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
-    public fun getLength(): Int {
-        return LLVM.LLVMGetArrayLength(llvmType)
+public class LLVMVectorType internal constructor(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun getSize(): Int {
+        return LLVM.LLVMGetVectorSize(llvmType)
     }
 
     public fun getSubtypes(): List<LLVMType> {
         // TODO: Learn how to test this
-        val dest = PointerPointer<LLVMTypeRef>(getLength().toLong())
+        val dest = PointerPointer<LLVMTypeRef>(getSize().toLong())
         LLVM.LLVMGetSubtypes(llvmType, dest)
 
         return dest.iterateIntoType { LLVMType(it) }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMArrayTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMArrayTypeTest.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMFunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMFunctionTypeTest.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.llvm.global.LLVM
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerTypeTest.kt
@@ -1,6 +1,7 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
 import dev.supergrecko.kllvm.core.LLVMContext
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.runAll
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMPointerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMPointerTypeTest.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMStructureTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMStructureTypeTest.kt
@@ -1,6 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
-import dev.supergrecko.kllvm.core.LLVMContext
+import dev.supergrecko.kllvm.core.LLVMType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeTest.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import dev.supergrecko.kllvm.utils.runAll
 import org.bytedeco.llvm.global.LLVM
 import org.junit.jupiter.api.Test
@@ -35,7 +36,7 @@ class LLVMTypeTest {
     @Test
     fun `casting won't fail when the underlying type is different`() {
         // This behavior is documented at LLVMType. There is no way
-        // to guarantee that the underlying type is valid or invalid
+        // to guarantee that the underlying types is valid or invalid
         val type = LLVMType.makeInteger(LLVMTypeKind.Integer.LLVM_I32_TYPE)
         val ptr = type.intoPointer()
         val underlying = ptr.getElementType()

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMVectorTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMVectorTypeTest.kt
@@ -1,5 +1,6 @@
-package dev.supergrecko.kllvm.core.type
+package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.core.LLVMType
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
This moves the LLVMType from /core/types to /core where it belongs