### PR TITLE
[typedef] Create all typedef stubs and move them into separate namespace

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typebuilders/ArrayBuilder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typebuilders/ArrayBuilder.kt
@@ -1,7 +1,7 @@
 package dev.supergrecko.kllvm.core.typebuilders
 
 import dev.supergrecko.kllvm.contracts.Builder
-import dev.supergrecko.kllvm.core.LLVMType
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.factories.TypeFactory
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typebuilders/StructBuilder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typebuilders/StructBuilder.kt
@@ -1,8 +1,8 @@
 package dev.supergrecko.kllvm.core.typebuilders
 
 import dev.supergrecko.kllvm.contracts.Builder
-import dev.supergrecko.kllvm.core.LLVMContext
-import dev.supergrecko.kllvm.core.LLVMType
+import dev.supergrecko.kllvm.core.typedefs.LLVMContext
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
 import dev.supergrecko.kllvm.factories.TypeFactory
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typebuilders/VectorBuilder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typebuilders/VectorBuilder.kt
@@ -1,7 +1,7 @@
 package dev.supergrecko.kllvm.core.typebuilders
 
 import dev.supergrecko.kllvm.contracts.Builder
-import dev.supergrecko.kllvm.core.LLVMType
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
 import dev.supergrecko.kllvm.factories.TypeFactory
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMAttribute.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMAttribute.kt
@@ -1,0 +1,6 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMAttributeRef
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef
+
+public class LLVMAttribute internal constructor(internal val llvmAttribute: LLVMAttributeRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMBasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMBasicBlock.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef
+
+public class LLVMBasicBlock internal constructor(internal val llvmBlock: LLVMBasicBlockRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMBinary.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMBinary.kt
@@ -1,0 +1,21 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import dev.supergrecko.kllvm.contracts.Disposable
+import dev.supergrecko.kllvm.contracts.Validatable
+import org.bytedeco.llvm.LLVM.LLVMBinaryRef
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef
+import org.bytedeco.llvm.global.LLVM
+
+public class LLVMBinary internal constructor(internal val llvmBinary: LLVMBinaryRef) : AutoCloseable, Validatable, Disposable {
+    public override var valid: Boolean = true
+
+    override fun dispose() {
+        require(valid) { "This binary has already been disposed." }
+
+        valid = false
+
+        LLVM.LLVMDisposeBinary(llvmBinary)
+    }
+
+    override fun close() = dispose()
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMBuilder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMBuilder.kt
@@ -1,0 +1,20 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import dev.supergrecko.kllvm.contracts.Disposable
+import dev.supergrecko.kllvm.contracts.Validatable
+import org.bytedeco.llvm.LLVM.LLVMBuilderRef
+import org.bytedeco.llvm.global.LLVM
+
+public class LLVMBuilder internal constructor(internal val llvmBuilder: LLVMBuilderRef) : AutoCloseable, Validatable, Disposable {
+    public override var valid: Boolean = true
+
+    override fun dispose() {
+        require(valid) { "This builder has already been disposed." }
+
+        valid = false
+
+        LLVM.LLVMDisposeBuilder(llvmBuilder)
+    }
+
+    override fun close() = dispose()
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMComdat.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMComdat.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMComdat
+
+public class LLVMComdat internal constructor(internal val llvmComdat: LLVMComdat)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMDiagnosticInfo.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMDiagnosticInfo.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMDiagnosticInfoRef
+
+public class LLVMDiagnosticInfo internal constructor(internal val llvmDiagnosticInfo: LLVMDiagnosticInfoRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMJitEventListener.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMJitEventListener.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMJITEventListenerRef
+
+public class LLVMJitEventListener internal constructor(internal val llvmListener: LLVMJITEventListenerRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMMemoryBuffer.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMMemoryBuffer.kt
@@ -1,0 +1,20 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import dev.supergrecko.kllvm.contracts.Disposable
+import dev.supergrecko.kllvm.contracts.Validatable
+import org.bytedeco.llvm.LLVM.LLVMMemoryBufferRef
+import org.bytedeco.llvm.global.LLVM
+
+public class LLVMMemoryBuffer internal constructor(internal val llvmBuffer: LLVMMemoryBufferRef) : AutoCloseable, Validatable, Disposable {
+    public override var valid: Boolean = true
+
+    override fun dispose() {
+        require(valid) { "This buffer has already been disposed." }
+
+        valid = false
+
+        LLVM.LLVMDisposeMemoryBuffer(llvmBuffer)
+    }
+
+    override fun close() = dispose()
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMMetadata.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMMetadata.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMMetadataRef
+
+public class LLVMMetadata internal constructor(internal val llvmMetadata: LLVMMetadataRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMModule.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMModule.kt
@@ -1,0 +1,20 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import dev.supergrecko.kllvm.contracts.Disposable
+import dev.supergrecko.kllvm.contracts.Validatable
+import org.bytedeco.llvm.LLVM.LLVMModuleRef
+import org.bytedeco.llvm.global.LLVM
+
+public class LLVMModule internal constructor(internal val llvmModule: LLVMModuleRef) : AutoCloseable, Validatable, Disposable {
+    public override var valid: Boolean = true
+
+    override fun dispose() {
+        require(valid) { "This module has already been disposed." }
+
+        valid = false
+
+        LLVM.LLVMDisposeModule(llvmModule)
+    }
+
+    override fun close() = dispose()
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMModuleProvider.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMModuleProvider.kt
@@ -1,0 +1,20 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import dev.supergrecko.kllvm.contracts.Disposable
+import dev.supergrecko.kllvm.contracts.Validatable
+import org.bytedeco.llvm.LLVM.LLVMModuleProviderRef
+import org.bytedeco.llvm.global.LLVM
+
+public class LLVMModuleProvider internal constructor(internal val llvmModuleProvider: LLVMModuleProviderRef) : AutoCloseable, Validatable, Disposable {
+    public override var valid: Boolean = true
+
+    override fun dispose() {
+        require(valid) { "This module has already been disposed." }
+
+        valid = false
+
+        LLVM.LLVMDisposeModuleProvider(llvmModuleProvider)
+    }
+
+    override fun close() = dispose()
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMNamedMetadataNode.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMNamedMetadataNode.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMNamedMDNodeRef
+
+public class LLVMNamedMetadataNode internal constructor(internal val llvmNamedMetadata: LLVMNamedMDNodeRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMPassManager.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMPassManager.kt
@@ -1,0 +1,20 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import dev.supergrecko.kllvm.contracts.Disposable
+import dev.supergrecko.kllvm.contracts.Validatable
+import org.bytedeco.llvm.LLVM.LLVMPassManagerRef
+import org.bytedeco.llvm.global.LLVM
+
+public class LLVMPassManager internal constructor(internal val llvmPass: LLVMPassManagerRef) : AutoCloseable, Validatable, Disposable {
+    public override var valid: Boolean = true
+
+    override fun dispose() {
+        require(valid) { "This module has already been disposed." }
+
+        valid = false
+
+        LLVM.LLVMDisposePassManager(llvmPass)
+    }
+
+    override fun close() = dispose()
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMPassRegistry.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMPassRegistry.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMPassRegistryRef
+
+public class LLVMPassRegistry internal constructor(internal val llvmRegistry: LLVMPassRegistryRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMType.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.kllvm.core
+package dev.supergrecko.kllvm.core.typedefs
 
 import dev.supergrecko.kllvm.annotation.ExpectsType
 import dev.supergrecko.kllvm.contracts.Unreachable

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMUse.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMUse.kt
@@ -1,0 +1,5 @@
+package dev.supergrecko.kllvm.core.typedefs
+
+import org.bytedeco.llvm.LLVM.LLVMUseRef
+
+public class LLVMUse internal constructor(internal val llvmUse: LLVMUseRef)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.kllvm.core
+package dev.supergrecko.kllvm.core.typedefs
 
 import dev.supergrecko.kllvm.core.enumerations.LLVMValueKind
 import dev.supergrecko.kllvm.utils.toBoolean
@@ -11,30 +11,24 @@ public class LLVMValue internal constructor(
         public var kind: LLVMValueKind = getValueKind(llvmValue)
 ) {
     //region Core::Types
-
     public fun isNull(): Boolean {
         return LLVM.LLVMIsNull(llvmValue).toBoolean()
     }
-
     //endregion Core::Types
-    //region Core::Values::Constants::ScalarConstants
 
+    //region Core::Values::Constants::ScalarConstants
     public fun getIntZeroExtValue(): Long { TODO() }
     public fun getIntSignExtValue(): Long { TODO() }
     public fun getRealDoubleValue(): Double { TODO() }
-
     //endregion Core::Values::Constants::ScalarConstants
-    //region Core::Values::Constants::CompositeConstants
 
+    //region Core::Values::Constants::CompositeConstants
     public fun isConstantString(): Boolean { TODO() }
     public fun getAsString(): Boolean { TODO() }
     public fun getElementAsConstant(index: Boolean): LLVMValue { TODO() }
-
     //endregion Core::Values::Constants::CompositeConstants
+
     //region Core::Values::Constants::ConstantExpressions
-
-
-
     //endregion Core::Values::Constants::ConstantExpressions
 
     /**

--- a/src/main/kotlin/dev/supergrecko/kllvm/factories/ConstantFactory.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/factories/ConstantFactory.kt
@@ -3,9 +3,9 @@ package dev.supergrecko.kllvm.factories
 import dev.supergrecko.kllvm.annotation.ExpectsType
 import dev.supergrecko.kllvm.annotation.RejectsType
 import dev.supergrecko.kllvm.contracts.Factory
-import dev.supergrecko.kllvm.core.LLVMContext
-import dev.supergrecko.kllvm.core.LLVMType
-import dev.supergrecko.kllvm.core.LLVMValue
+import dev.supergrecko.kllvm.core.typedefs.LLVMContext
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import dev.supergrecko.kllvm.core.typedefs.LLVMValue
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
 import dev.supergrecko.kllvm.utils.Radix
 import org.bytedeco.llvm.LLVM.LLVMValueRef

--- a/src/main/kotlin/dev/supergrecko/kllvm/factories/TypeFactory.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/factories/TypeFactory.kt
@@ -1,8 +1,8 @@
 package dev.supergrecko.kllvm.factories
 
 import dev.supergrecko.kllvm.contracts.Factory
-import dev.supergrecko.kllvm.core.LLVMContext
-import dev.supergrecko.kllvm.core.LLVMType
+import dev.supergrecko.kllvm.core.typedefs.LLVMContext
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
 import dev.supergrecko.kllvm.core.typebuilders.StructBuilder
 import dev.supergrecko.kllvm.core.typebuilders.VectorBuilder

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/LLVMContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/LLVMContextTest.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.core
 
+import dev.supergrecko.kllvm.core.typedefs.LLVMContext
 import dev.supergrecko.kllvm.utils.runAll
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -23,7 +24,7 @@ class LLVMContextTest {
         ctx.dispose()
 
         assertFailsWith<IllegalArgumentException> {
-            LLVMContext.disposeContext(ctx)
+            ctx.dispose()
         }
     }
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerTypeTest.kt
@@ -1,6 +1,6 @@
 package dev.supergrecko.kllvm.core.types
 
-import dev.supergrecko.kllvm.core.LLVMContext
+import dev.supergrecko.kllvm.core.typedefs.LLVMContext
 import dev.supergrecko.kllvm.factories.TypeFactory
 import dev.supergrecko.kllvm.utils.runAll
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeTest.kt
@@ -1,6 +1,6 @@
 package dev.supergrecko.kllvm.core.types
 
-import dev.supergrecko.kllvm.core.LLVMContext
+import dev.supergrecko.kllvm.core.typedefs.LLVMContext
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
 import dev.supergrecko.kllvm.factories.TypeFactory
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/values/LLVMValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/values/LLVMValueTest.kt
@@ -1,6 +1,5 @@
 package dev.supergrecko.kllvm.core.values
 
-import dev.supergrecko.kllvm.core.LLVMValue
 import dev.supergrecko.kllvm.core.enumerations.LLVMValueKind
 import dev.supergrecko.kllvm.factories.ConstantFactory
 import dev.supergrecko.kllvm.factories.TypeFactory


### PR DESCRIPTION
This creates most, if not all the *Ref's from LLVM inside a core.typedefs module.