### PR TITLE
[api] Refactor Types into multiple subtypes

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMType.kt
@@ -1,43 +1,26 @@
 package dev.supergrecko.kllvm.core.typedefs
 
-import dev.supergrecko.kllvm.contracts.Unreachable
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
 import dev.supergrecko.kllvm.core.message.Message
+import dev.supergrecko.kllvm.core.types.*
 import dev.supergrecko.kllvm.factories.TypeFactory
-import dev.supergrecko.kllvm.utils.*
-import org.bytedeco.javacpp.PointerPointer
+import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-/**
- * Higher level wrapper around LLVM Core's types module
- *
- * -[Documentation](https://llvm.org/doxygen/group__LLVMCCoreType.html)
- */
 public open class LLVMType internal constructor(
-        internal val llvmType: LLVMTypeRef,
-        public var kind: LLVMTypeKind = getTypeKind(llvmType)
+        internal val llvmType: LLVMTypeRef
 ) {
     //region Core::Types
+    public fun getTypeKind(): LLVMTypeKind {
+        return getTypeKind(llvmType)
+    }
 
-    /**
-     * Get the type kind for this type
-     */
-    public fun getTypeKind(): LLVMTypeKind = getTypeKind(llvmType)
-
-    /**
-     * Determine whether this type has a known size or not
-     */
     public fun isSized(): Boolean {
         return LLVM.LLVMTypeIsSized(llvmType).toBoolean()
     }
 
-    /**
-     * Get the context this type resides in
-     */
     public fun getContext(): LLVMContext {
-        require(!isInTypeKinds(LLVMTypeKind.Function, LLVMTypeKind.Array, LLVMTypeKind.Pointer, LLVMTypeKind.Vector))
-
         val ctx = LLVM.LLVMGetTypeContext(llvmType)
 
         return LLVMContext(ctx)
@@ -53,264 +36,23 @@ public open class LLVMType internal constructor(
 
         return Message(ptr.asBuffer())
     }
-
     //endregion Core::Types
-    //region Core::Types::StructureTypes
 
-    /**
-     * Accepts [LLVMTypeKind.Struct]
-     */
-    public fun isStructPacked(): Boolean {
-        require(isTypeKind(LLVMTypeKind.Struct))
-
-        return LLVM.LLVMIsPackedStruct(llvmType).toBoolean()
-    }
-
-    /**
-     * Accepts [LLVMTypeKind.Struct]
-     */
-    public fun isStructOpaque(): Boolean {
-        require(isTypeKind(LLVMTypeKind.Struct))
-
-        return LLVM.LLVMIsOpaqueStruct(llvmType).toBoolean()
-    }
-
-    /**
-     * Accepts [LLVMTypeKind.Struct]
-     */
-    public fun isStructLiteral(): Boolean {
-        require(isTypeKind(LLVMTypeKind.Struct))
-
-        return LLVM.LLVMIsLiteralStruct(llvmType).toBoolean()
-    }
-
-    /**
-     * Set the struct body for an opaque struct
-     *
-     * Accepts [LLVMTypeKind.Struct]
-     */
-    public fun setStructBody(elementTypes: List<LLVMType>, packed: Boolean) {
-        require(isTypeKind(LLVMTypeKind.Struct))
-        require(isStructOpaque())
-
-        val types = elementTypes.map { it.llvmType }
-        val array = ArrayList(types).toTypedArray()
-        val ptr = PointerPointer(*array)
-
-        LLVM.LLVMStructSetBody(llvmType, ptr, array.size, packed.toInt())
-    }
-
-    /**
-     * Get the element type from the struct at index [index]
-     *
-     * Accepts [LLVMTypeKind.Struct]
-     */
-    public fun getStructElementTypeAt(index: Int): LLVMType {
-        require(isTypeKind(LLVMTypeKind.Struct))
-        require(index <= getSequentialElementSize()) { "Requested index $index is out of bounds for this struct" }
-
-        val type = LLVM.LLVMStructGetTypeAtIndex(llvmType, index)
-
-        return LLVMType(type, getTypeKind(type))
-    }
-
-    /**
-     * Get the struct name if it has a name
-     *
-     * Accepts [LLVMTypeKind.Struct]
-     */
-    public fun getStructName(): String? {
-        require(isTypeKind(LLVMTypeKind.Struct))
-
-        // TODO: Resolve IllegalStateException
-        val name = LLVM.LLVMGetStructName(llvmType)
-
-        return if (name.bool) {
-            null
-        } else {
-            name.string
-        }
-    }
-
-    /**
-     * Get the types of the elements in this struct
-     *
-     * Accepts [LLVMTypeKind.Struct]
-     */
-    public fun getStructElementTypes(): List<LLVMType> {
-        require(isTypeKind(LLVMTypeKind.Struct))
-
-        val dest = PointerPointer<LLVMTypeRef>(getSequentialElementSize().toLong())
-        LLVM.LLVMGetStructElementTypes(llvmType, dest)
-
-        return dest.iterateIntoType { LLVMType(it, getTypeKind(it)) }
-    }
-
-    //endregion Core::Types::StructureTypes
-    //region Core::Types::SequentialTypes
-
-    /**
-     * Get the declared address space for this pointer
-     *
-     * Accepts [LLVMTypeKind.Pointer]
-     */
-    public fun getPointerAddressSpace(): Int {
-        require(isTypeKind(LLVMTypeKind.Pointer))
-
-        return LLVM.LLVMGetPointerAddressSpace(llvmType)
-    }
-
-    /**
-     * Get the amount of bits this integer type can hold
-     *
-     * Accepts [LLVMTypeKind.Integer]
-     */
-    public fun getIntegerTypeWidth(): Int {
-        require(isTypeKind(LLVMTypeKind.Integer))
-
-        return LLVM.LLVMGetIntTypeWidth(llvmType)
-    }
-
-    /**
-     * Get the amount of elements for this type
-     *
-     * Accepts [LLVMTypeKind.Array]: Allocated array size
-     * Accepts [LLVMTypeKind.Vector]: Vector size
-     * Accepts [LLVMTypeKind.Pointer]: Number of derived types
-     * Accepts [LLVMTypeKind.Struct]: Number of elements in struct body
-     */
-    public fun getSequentialElementSize(): Int {
-        require(isInTypeKinds(LLVMTypeKind.Array, LLVMTypeKind.Vector, LLVMTypeKind.Pointer, LLVMTypeKind.Struct))
-
-        return when (kind) {
-            LLVMTypeKind.Array -> LLVM.LLVMGetArrayLength(llvmType)
-            LLVMTypeKind.Vector -> LLVM.LLVMGetVectorSize(llvmType)
-            LLVMTypeKind.Pointer -> LLVM.LLVMGetNumContainedTypes(llvmType)
-            LLVMTypeKind.Struct -> LLVM.LLVMCountStructElementTypes(llvmType)
-            else -> throw Unreachable()
-        }
-    }
-
-    /**
-     * Get the subtype of this type
-     *
-     * Accepts [LLVMTypeKind.Array]
-     * Accepts [LLVMTypeKind.Pointer]
-     * Accepts [LLVMTypeKind.Vector]
-     *
-     * TODO: Learn how to test this
-     */
-    public fun getSequentialSubtypes(): List<LLVMType> {
-        require(isInTypeKinds(LLVMTypeKind.Array, LLVMTypeKind.Pointer, LLVMTypeKind.Vector))
-
-        val dest = PointerPointer<LLVMTypeRef>(getSequentialElementSize().toLong())
-        LLVM.LLVMGetSubtypes(llvmType, dest)
-
-        return dest.iterateIntoType { LLVMType(it, getTypeKind(it)) }
-    }
-
-    /**
-     * Get the underlying element's type
-     *
-     * Accepts [LLVMTypeKind.Array]
-     * Accepts [LLVMTypeKind.Pointer]
-     * Accepts [LLVMTypeKind.Vector]
-     */
-    public fun getSequentialElementType(): LLVMType {
-        require(isInTypeKinds(LLVMTypeKind.Array, LLVMTypeKind.Pointer, LLVMTypeKind.Vector))
-
-        val type = LLVM.LLVMGetElementType(llvmType)
-
-        return LLVMType(type, getTypeKind(type))
-    }
-
-    //endregion Core::Types::SequentialTypes
-    //region Core::Types::FunctionTypes
-
-    /**
-     * Determine whether this function accepts variadic arguments
-     *
-     * Accepts [LLVMTypeKind.Function]
-     */
-    public fun isFunctionVariadic(): Boolean {
-        require(isTypeKind(LLVMTypeKind.Function))
-
-        return LLVM.LLVMIsFunctionVarArg(llvmType).toBoolean()
-    }
-
-    /**
-     * Accepts [LLVMTypeKind.Function]
-     */
-    public fun getFunctionParameterCount(): Int {
-        require(isTypeKind(LLVMTypeKind.Function))
-
-        return LLVM.LLVMCountParamTypes(llvmType)
-    }
-
-    /**
-     * Get the return type of the function
-     *
-     * Accepts [LLVMTypeKind.Function]
-     */
-    public fun getFunctionReturnType(): LLVMType {
-        require(isTypeKind(LLVMTypeKind.Function))
-
-        val type = LLVM.LLVMGetReturnType(llvmType)
-
-        return LLVMType(type, getTypeKind(type))
-    }
-
-    /**
-     * Get the types of this function's parameters
-     *
-     * Accepts [LLVMTypeKind.Function]
-     */
-    public fun getFunctionParameterTypes(): List<LLVMType> {
-        require(isTypeKind(LLVMTypeKind.Function))
-
-        val dest = PointerPointer<LLVMTypeRef>(getFunctionParameterCount().toLong())
-        LLVM.LLVMGetParamTypes(llvmType, dest)
-
-        return dest
-                .iterateIntoType { LLVMType(it, getTypeKind(it)) }
-    }
-
-    //endregion Core::Types::FunctionTypes
-
-    /**
-     * "Cast" into another LLVMType
-     *
-     * This cast is not safe as there is no guarantee that the underlying type matches
-     * the requested type.
-     */
-    public fun cast(intoTypeKind: LLVMTypeKind): LLVMType {
-        kind = intoTypeKind
-
-        return this
-    }
-
-    /**
-     * Wrap this type inside a pointer
-     */
+    // TODO: refactor with factories
     public fun toPointerType(addressSpace: Int = 0): LLVMType = TypeFactory.pointer(this, addressSpace)
 
-    /**
-     * Wrap this type inside an array
-     */
     public fun toArrayType(size: Int): LLVMType = TypeFactory.array(this, size)
 
-    /**
-     * Wrap this type inside a vector
-     */
     public fun toVectorType(size: Int): LLVMType = TypeFactory.vector(this, size)
 
-    public fun isTypeKind(kind: LLVMTypeKind): Boolean {
-        return kind == this.kind
-    }
-
-    public fun isInTypeKinds(vararg kinds: LLVMTypeKind): Boolean {
-        return kind in kinds
-    }
+    public fun asArrayType(): ArrayType = ArrayType(llvmType)
+    public fun asFloatType(): FloatType = FloatType(llvmType)
+    public fun asFunctionType(): FunctionType = FunctionType(llvmType)
+    public fun asIntType(): IntType = IntType(llvmType)
+    public fun asPointerType(): PointerType = PointerType(llvmType)
+    public fun asStructType(): StructType = StructType(llvmType)
+    public fun asVectorType(): VectorType = VectorType(llvmType)
+    public fun asVoidType(): VoidType = VoidType(llvmType)
 
     companion object {
         @JvmStatic

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMType.kt
@@ -12,8 +12,6 @@ import java.lang.reflect.Constructor
 public open class LLVMType internal constructor(
         internal val llvmType: LLVMTypeRef
 ) {
-    internal constructor() : this(LLVMTypeRef())
-
     //region Core::Types
     public fun getTypeKind(): LLVMTypeKind {
         return getTypeKind(llvmType)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
@@ -19,7 +19,7 @@ public open class LLVMValue internal constructor(
     public fun getType(): LLVMType {
         val type = LLVM.LLVMTypeOf(llvmValue)
 
-        return LLVMType(type, LLVMType.getTypeKind(type))
+        return LLVMType(type)
     }
 
     public fun isUndef(): Boolean {

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
@@ -7,8 +7,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public open class LLVMValue internal constructor(
-        internal val llvmValue: LLVMValueRef,
-        public var kind: LLVMValueKind = getValueKind(llvmValue)
+        internal val llvmValue: LLVMValueRef
 ) {
     //region Core::Values::Constants
     public fun isNull(): Boolean {

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/LLVMValue.kt
@@ -3,8 +3,10 @@ package dev.supergrecko.kllvm.core.typedefs
 import dev.supergrecko.kllvm.core.enumerations.LLVMValueKind
 import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.javacpp.SizeTPointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
+import java.lang.reflect.Constructor
 
 public open class LLVMValue internal constructor(
         internal val llvmValue: LLVMValueRef
@@ -60,6 +62,15 @@ public open class LLVMValue internal constructor(
     public fun isAMDNode() {}
     public fun isAMDString() {}
     //endregion Core::Values::Constants::GeneralAPIs
+
+    public inline fun <reified T : LLVMValue> cast(): T {
+        val ctor: Constructor<T> = T::class.java.getDeclaredConstructor(LLVMValueRef::class.java)
+
+        return ctor.newInstance(getUnderlyingReference())
+                ?: throw TypeCastException("Failed to cast LLVMType to T")
+    }
+
+    public fun getUnderlyingReference(): LLVMValueRef = llvmValue
 
     public companion object {
         /**

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
@@ -1,0 +1,27 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import dev.supergrecko.kllvm.utils.iterateIntoType
+import org.bytedeco.javacpp.PointerPointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+public class ArrayType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun getElementCount(): Int {
+        return LLVM.LLVMGetArrayLength(llvmType)
+    }
+
+    public fun getSubtypes(): List<LLVMType> {
+        // TODO: Learn how to test this
+        val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
+        LLVM.LLVMGetSubtypes(llvmType, dest)
+
+        return dest.iterateIntoType { LLVMType(it) }
+    }
+
+    public fun getElementType(): LLVMType {
+        val type = LLVM.LLVMGetElementType(llvmType)
+
+        return LLVMType(type)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
@@ -1,0 +1,6 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+
+public class FloatType(llvmType: LLVMTypeRef) : LLVMType(llvmType)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
@@ -8,8 +8,6 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class FunctionType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
-    internal constructor(): this(LLVMTypeRef())
-
     public fun isVariadic(): Boolean {
         return LLVM.LLVMIsFunctionVarArg(llvmType).toBoolean()
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
@@ -1,0 +1,32 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import dev.supergrecko.kllvm.utils.iterateIntoType
+import dev.supergrecko.kllvm.utils.toBoolean
+import org.bytedeco.javacpp.PointerPointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+public class FunctionType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun isVariadic(): Boolean {
+        return LLVM.LLVMIsFunctionVarArg(llvmType).toBoolean()
+    }
+
+    public fun getParameterCount(): Int {
+        return LLVM.LLVMCountParamTypes(llvmType)
+    }
+
+    public fun getReturnType(): LLVMType {
+        val type = LLVM.LLVMGetReturnType(llvmType)
+
+        return LLVMType(type)
+    }
+
+    public fun getParameterTypes(): List<LLVMType> {
+        val dest = PointerPointer<LLVMTypeRef>(getParameterCount().toLong())
+        LLVM.LLVMGetParamTypes(llvmType, dest)
+
+        return dest
+                .iterateIntoType { LLVMType(it) }
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
@@ -8,6 +8,8 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class FunctionType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    internal constructor(): this(LLVMTypeRef())
+
     public fun isVariadic(): Boolean {
         return LLVM.LLVMIsFunctionVarArg(llvmType).toBoolean()
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
@@ -1,0 +1,11 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+public class IntType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun getTypeWidth(): Int {
+        return LLVM.LLVMGetIntTypeWidth(llvmType)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/PointerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/PointerType.kt
@@ -1,0 +1,31 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import dev.supergrecko.kllvm.utils.iterateIntoType
+import org.bytedeco.javacpp.PointerPointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+public class PointerType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun getAddressSpace(): Int {
+        return LLVM.LLVMGetPointerAddressSpace(llvmType)
+    }
+
+    public fun getElementCount(): Int {
+        return LLVM.LLVMGetNumContainedTypes(llvmType)
+    }
+
+    public fun getSubtypes(): List<LLVMType> {
+        // TODO: Learn how to test this
+        val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
+        LLVM.LLVMGetSubtypes(llvmType, dest)
+
+        return dest.iterateIntoType { LLVMType(it) }
+    }
+
+    public fun getElementType(): LLVMType {
+        val type = LLVM.LLVMGetElementType(llvmType)
+
+        return LLVMType(type)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
@@ -1,0 +1,64 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import dev.supergrecko.kllvm.utils.iterateIntoType
+import dev.supergrecko.kllvm.utils.toBoolean
+import dev.supergrecko.kllvm.utils.toInt
+import org.bytedeco.javacpp.PointerPointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+public class StructType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun isPacked(): Boolean {
+        return LLVM.LLVMIsPackedStruct(llvmType).toBoolean()
+    }
+
+    public fun isOpaque(): Boolean {
+        return LLVM.LLVMIsOpaqueStruct(llvmType).toBoolean()
+    }
+
+    public fun isLiteral(): Boolean {
+        return LLVM.LLVMIsLiteralStruct(llvmType).toBoolean()
+    }
+
+    public fun setBody(elementTypes: List<LLVMType>, packed: Boolean) {
+        require(isOpaque())
+
+        val types = elementTypes.map { it.llvmType }
+        val array = ArrayList(types).toTypedArray()
+        val ptr = PointerPointer(*array)
+
+        LLVM.LLVMStructSetBody(llvmType, ptr, array.size, packed.toInt())
+    }
+
+    public fun getElementTypeAt(index: Int): LLVMType {
+        // Refactor when moved
+        require(index <= getElementCount()) { "Requested index $index is out of bounds for this struct" }
+
+        val type = LLVM.LLVMStructGetTypeAtIndex(llvmType, index)
+
+        return LLVMType(type)
+    }
+
+    public fun getName(): String? {
+        // TODO: Resolve IllegalStateException
+        val name = LLVM.LLVMGetStructName(llvmType)
+
+        return if (name.bool) {
+            null
+        } else {
+            name.string
+        }
+    }
+
+    public fun getElementTypes(): List<LLVMType> {
+        val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
+        LLVM.LLVMGetStructElementTypes(llvmType, dest)
+
+        return dest.iterateIntoType { LLVMType(it) }
+    }
+
+    public fun getElementCount(): Int {
+        return LLVM.LLVMCountStructElementTypes(llvmType)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
@@ -1,0 +1,27 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import dev.supergrecko.kllvm.utils.iterateIntoType
+import org.bytedeco.javacpp.PointerPointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+import org.bytedeco.llvm.global.LLVM
+
+public class VectorType(llvmType: LLVMTypeRef) : LLVMType(llvmType) {
+    public fun getElementCount(): Int {
+        return LLVM.LLVMGetVectorSize(llvmType)
+    }
+
+    public fun getSubtypes(): List<LLVMType> {
+        // TODO: Learn how to test this
+        val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
+        LLVM.LLVMGetSubtypes(llvmType, dest)
+
+        return dest.iterateIntoType { LLVMType(it) }
+    }
+
+    public fun getElementType(): LLVMType {
+        val type = LLVM.LLVMGetElementType(llvmType)
+
+        return LLVMType(type)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
@@ -1,0 +1,6 @@
+package dev.supergrecko.kllvm.core.types
+
+import dev.supergrecko.kllvm.core.typedefs.LLVMType
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
+
+public class VoidType(llvmType: LLVMTypeRef) : LLVMType(llvmType)

--- a/src/main/kotlin/dev/supergrecko/kllvm/dsl/ArrayBuilder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/dsl/ArrayBuilder.kt
@@ -4,16 +4,17 @@ import dev.supergrecko.kllvm.contracts.Builder
 import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.factories.TypeFactory
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
+import dev.supergrecko.kllvm.core.types.ArrayType
 
 /**
  * Builder class to construct an array type
  *
  * This is a DSL for building [LLVMTypeKind.Array] types.
  */
-public class ArrayBuilder(public val size: Int) : Builder<LLVMType> {
+public class ArrayBuilder(public val size: Int) : Builder<ArrayType> {
     public lateinit var type: LLVMType
 
-    public override fun build(): LLVMType {
+    public override fun build(): ArrayType {
         return TypeFactory.array(type, size)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/dsl/StructBuilder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/dsl/StructBuilder.kt
@@ -4,6 +4,7 @@ import dev.supergrecko.kllvm.contracts.Builder
 import dev.supergrecko.kllvm.core.typedefs.LLVMContext
 import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
+import dev.supergrecko.kllvm.core.types.StructType
 import dev.supergrecko.kllvm.factories.TypeFactory
 
 /**
@@ -11,7 +12,7 @@ import dev.supergrecko.kllvm.factories.TypeFactory
  *
  * This is a DSL for building [LLVMTypeKind.Struct] types. This builder does not build opaque types.
  */
-public class StructBuilder : Builder<LLVMType> {
+public class StructBuilder : Builder<StructType> {
     public var context = LLVMContext.getGlobalContext()
     public var packed = false
     internal val types: MutableList<LLVMType> = mutableListOf()
@@ -20,7 +21,7 @@ public class StructBuilder : Builder<LLVMType> {
         types.add(type)
     }
 
-    public override fun build(): LLVMType {
+    public override fun build(): StructType {
         return TypeFactory.struct(types, packed, context)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/dsl/VectorBuilder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/dsl/VectorBuilder.kt
@@ -3,6 +3,7 @@ package dev.supergrecko.kllvm.dsl
 import dev.supergrecko.kllvm.contracts.Builder
 import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
+import dev.supergrecko.kllvm.core.types.VectorType
 import dev.supergrecko.kllvm.factories.TypeFactory
 
 /**
@@ -10,10 +11,10 @@ import dev.supergrecko.kllvm.factories.TypeFactory
  *
  * This is a DSL for building [LLVMTypeKind.Vector] types.
  */
-public class VectorBuilder(public val size: Int) : Builder<LLVMType> {
+public class VectorBuilder(public val size: Int) : Builder<VectorType> {
     public lateinit var type: LLVMType
 
-    public override fun build(): LLVMType {
+    public override fun build(): VectorType {
         return TypeFactory.vector(type, size)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/factories/ConstantFactory.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/factories/ConstantFactory.kt
@@ -5,6 +5,7 @@ import dev.supergrecko.kllvm.core.typedefs.LLVMContext
 import dev.supergrecko.kllvm.core.typedefs.LLVMType
 import dev.supergrecko.kllvm.core.typedefs.LLVMValue
 import dev.supergrecko.kllvm.core.enumerations.LLVMTypeKind
+import dev.supergrecko.kllvm.core.types.StructType
 import dev.supergrecko.kllvm.utils.Radix
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
@@ -13,10 +14,8 @@ public object ConstantFactory : Factory<LLVMValue> {
     //region Core::Values::Constants
 
     public fun constNull(type: LLVMType): LLVMValue {
-        require(!type.isInTypeKinds(LLVMTypeKind.Function, LLVMTypeKind.Label))
-
-        if (type.isTypeKind(LLVMTypeKind.Struct)) {
-            require(!type.isStructOpaque())
+        if (type is StructType) {
+            require(!type.isOpaque())
         }
 
         val value = LLVM.LLVMConstNull(type.llvmType)
@@ -25,8 +24,6 @@ public object ConstantFactory : Factory<LLVMValue> {
     }
 
     public fun constAllOnes(type: LLVMType): LLVMValue {
-        require(type.isTypeKind(LLVMTypeKind.Integer))
-
         val value = LLVM.LLVMConstAllOnes(type.llvmType)
 
         return LLVMValue(value)

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMArrayTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMArrayTypeTest.kt
@@ -11,8 +11,8 @@ class LLVMArrayTypeTest {
         val type = TypeFactory.integer(32)
         val arr = TypeFactory.array(type, 10)
 
-        assertEquals(10, arr.getSequentialElementSize())
-        assertEquals(type.llvmType, arr.getSequentialElementType().llvmType)
+        assertEquals(10, arr.getElementCount())
+        assertEquals(type.llvmType, arr.getElementType().llvmType)
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMFunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMFunctionTypeTest.kt
@@ -14,8 +14,8 @@ class LLVMFunctionTypeTest {
         val ret = TypeFactory.integer(64)
         val fn = TypeFactory.function(ret, listOf(), true)
 
-        assertEquals(fn.getFunctionParameterCount(), 0)
-        assertTrue { fn.getFunctionReturnType().llvmType == ret.llvmType }
+        assertEquals(fn.getParameterCount(), 0)
+        assertTrue { fn.getReturnType().llvmType == ret.llvmType }
     }
 
     @Test
@@ -24,7 +24,7 @@ class LLVMFunctionTypeTest {
         val args = listOf(TypeFactory.float(LLVMTypeKind.Float))
         val fn = TypeFactory.function(ret, args, true)
 
-        assertEquals(fn.isFunctionVariadic(), true)
+        assertEquals(fn.isVariadic(), true)
     }
 
     @Test
@@ -33,7 +33,7 @@ class LLVMFunctionTypeTest {
         val args = listOf(TypeFactory.float(LLVMTypeKind.Float))
         val fn = TypeFactory.function(ret, args, true)
 
-        assertEquals(LLVM.LLVMIsFunctionVarArg(fn.llvmType).toBoolean(), fn.isFunctionVariadic())
+        assertEquals(LLVM.LLVMIsFunctionVarArg(fn.llvmType).toBoolean(), fn.isVariadic())
     }
 
     @Test
@@ -42,7 +42,7 @@ class LLVMFunctionTypeTest {
         val args = listOf(TypeFactory.float(LLVMTypeKind.Float))
         val fn = TypeFactory.function(ret, args, true)
 
-        assertEquals(LLVM.LLVMCountParamTypes(fn.llvmType), fn.getFunctionParameterCount())
+        assertEquals(LLVM.LLVMCountParamTypes(fn.llvmType), fn.getParameterCount())
     }
 
     @Test
@@ -51,7 +51,7 @@ class LLVMFunctionTypeTest {
         val args = listOf(TypeFactory.float(LLVMTypeKind.Float))
         val fn = TypeFactory.function(ret, args, true)
 
-        val params = fn.getFunctionParameterTypes()
+        val params = fn.getParameterTypes()
 
         for (i in args.indices) {
             val x = params[i].llvmType

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMIntegerTypeTest.kt
@@ -16,7 +16,7 @@ class LLVMIntegerTypeTest {
             val contextType = TypeFactory.integer(it, ctx)
             val globalType = TypeFactory.integer(it)
 
-            assertEquals(contextType.getIntegerTypeWidth(), globalType.getIntegerTypeWidth())
+            assertEquals(contextType.getTypeWidth(), globalType.getTypeWidth())
         }
     }
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMPointerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMPointerTypeTest.kt
@@ -10,7 +10,7 @@ class LLVMPointerTypeTest {
         val type = TypeFactory.integer(32)
         val ptr = type.toPointerType()
 
-        assertEquals(type.llvmType, ptr.getSequentialElementType().llvmType)
+        assertEquals(type.llvmType, ptr.getElementType().llvmType)
     }
 
     @Test
@@ -18,6 +18,6 @@ class LLVMPointerTypeTest {
         val type = TypeFactory.integer(32)
         val ptr = type.toPointerType(100)
 
-        assertEquals(100, ptr.getPointerAddressSpace())
+        assertEquals(100, ptr.getAddressSpace())
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMStructureTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMStructureTypeTest.kt
@@ -10,15 +10,15 @@ class LLVMStructureTypeTest {
         val elements = listOf(TypeFactory.integer(32))
         val struct = TypeFactory.struct(elements, false)
 
-        assertEquals(false, struct.isStructPacked())
-        assertEquals(1, struct.getSequentialElementSize())
-        assertEquals(true, struct.isStructLiteral())
-        assertEquals(false, struct.isStructOpaque())
+        assertEquals(false, struct.isPacked())
+        assertEquals(1, struct.getElementCount())
+        assertEquals(true, struct.isLiteral())
+        assertEquals(false, struct.isOpaque())
 
-        val (first) = struct.getStructElementTypes()
+        val (first) = struct.getElementTypes()
         assertEquals(elements.first().llvmType, first.llvmType)
 
-        val type = struct.getStructElementTypeAt(0)
+        val type = struct.getElementTypeAt(0)
         assertEquals(type.llvmType, elements.first().llvmType)
     }
 
@@ -26,13 +26,13 @@ class LLVMStructureTypeTest {
     fun `test opaque struct`() {
         val struct = TypeFactory.opaque("test_struct")
 
-        assertEquals(true, struct.isStructOpaque())
+        assertEquals(true, struct.isOpaque())
 
         val elements = listOf(TypeFactory.integer(32))
-        struct.setStructBody(elements, false)
+        struct.setBody(elements, false)
 
-        val (first) = struct.getStructElementTypes()
+        val (first) = struct.getElementTypes()
         assertEquals(elements.first().llvmType, first.llvmType)
-        assertEquals(false, struct.isStructOpaque())
+        assertEquals(false, struct.isOpaque())
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMTypeTest.kt
@@ -22,7 +22,7 @@ class LLVMTypeTest {
         val arr = type.toArrayType(10)
 
         assertEquals(LLVMTypeKind.Array, arr.getTypeKind())
-        assertEquals(10, arr.getSequentialElementSize())
+        assertEquals(10, arr.getElementCount())
     }
 
     @Test
@@ -31,16 +31,16 @@ class LLVMTypeTest {
         val vec = type.toVectorType(1000)
 
         assertEquals(LLVMTypeKind.Vector, vec.getTypeKind())
-        assertEquals(1000, vec.getSequentialElementSize())
+        assertEquals(1000, vec.getElementCount())
     }
 
     @Test
     fun `casting into other type works when expected to`() {
         val type = TypeFactory.integer(32)
         val ptr = type.toPointerType()
-        val underlying = ptr.getSequentialElementType()
+        val underlying = ptr.getElementType()
 
-        assertEquals(type.llvmType, underlying.cast(LLVMTypeKind.Integer).llvmType)
+        assertEquals(type.llvmType, underlying.cast<IntType>().llvmType)
     }
 
     @Test
@@ -49,9 +49,9 @@ class LLVMTypeTest {
         // to guarantee that the underlying types is valid or invalid
         val type = TypeFactory.integer(32)
         val ptr = type.toPointerType()
-        val underlying = ptr.getSequentialElementType()
+        val underlying = ptr.getElementType()
 
-        assertEquals(type.llvmType, underlying.cast(LLVMTypeKind.Function).llvmType)
+        assertEquals(type.llvmType, underlying.cast<FunctionType>().llvmType)
     }
 
     @Test
@@ -59,15 +59,6 @@ class LLVMTypeTest {
         val type = TypeFactory.float(LLVMTypeKind.Float)
 
         assertEquals(LLVMTypeKind.Float, type.getTypeKind())
-    }
-
-    @Test
-    fun `calling function with different type fails`() {
-        val type = TypeFactory.float(LLVMTypeKind.Float)
-
-        assertFailsWith<IllegalArgumentException> {
-            type.getSequentialElementSize()
-        }
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMVectorTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/LLVMVectorTypeTest.kt
@@ -12,8 +12,8 @@ class LLVMVectorTypeTest {
         val type = TypeFactory.integer(32)
         val vec = TypeFactory.vector(type, 10)
 
-        assertEquals(10, vec.getSequentialElementSize())
-        assertEquals(type.llvmType, vec.getSequentialElementType().llvmType)
+        assertEquals(10, vec.getElementCount())
+        assertEquals(type.llvmType, vec.getElementType().llvmType)
     }
 
     @Test


### PR DESCRIPTION
Expressing the LLVM Type system with Kotlin inheritance gives us a more concise and clear way to work with the LLVM in Kotlin.

Whenever you are unsure of which type was actually returned from a function we can match its typekind and we are also able to use LLVMType.cast to cast it into other types.