### PR TITLE
[docs] Add code of conduct and contributing guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team on [Discord](https://discord.gg/DFjN6RN). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+If you are interested in contributing to KLLVM's development feel free to go through the existing list of issues. 
+You can contact the maintainers via Discord. [Invite Link](https://discord.gg/DFjN6RN).
+
+Discord is our primary form for communication outside of GitHub.
+
+We have a [code of conduct](CODE_OF_CONDUCT.md) which we expect you to follow.
+
+### Pull Request Process
+
+1. Ensure files which are not supposed to be commited are removed. (eg .env, build/)
+1. If your code performs any breaking changes, update tests
+
+It is up to the maintainers to decide whether a feature/pull request is necessary.
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team on [Discord](https://discord.gg/DFjN6RN). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -1,0 +1,9 @@
+# Code Style
+
+KLLVM follows the Kotlin Coding Conventions (https://kotlinlang.org/docs/reference/coding-conventions.html)
+
+Because KLLVM is a library, we should also use these recommended rules to ensure API stability:
+
+- Always explicitly specify member visibility (to avoid accidentally exposing declarations as public API)
+- Always explicitly specify function return types and property types (to avoid accidentally changing the return type when the implementation changes)
+- Provide KDoc comments for all public members, with the exception of overrides that do not require any new documentation (to support generating documentation for the library)

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -1,0 +1,15 @@
+# Setup
+
+We recommend developing KLLVM in a modern IDE like IntelliJ which supports syntax highlighting and autocompletion for Kotlin.
+
+IntelliJ has a community version available which has those features. Download here: https://www.jetbrains.com/idea/download
+
+## Getting Started
+
+- Clone the Repository using Git
+- Open it with IntelliJ
+- Open project as Gradle project
+    - Documentation for working with Gradle in IntelliJ found [here.](https://www.jetbrains.com/help/idea/work-with-gradle-projects.html)
+- Run the Test gradle task to verify everything is working
+    - Documentation for running gradle tasks found [here.](https://www.jetbrains.com/help/idea/work-with-gradle-tasks.html)
+    - You may also run `./gradlew test` in your command line from the project root directory.


### PR DESCRIPTION
This adds a basic code of conduct and fills out basic contributing guidelines. These are taken from the Contributor Covenant and are subject to change as the project develops. 