### PR TITLE
[refactor] Use secondary constructors and companions for creation of objects

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/message/Message.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/message/Message.kt
@@ -10,8 +10,11 @@ import java.nio.ByteBuffer
  * A [Message] is a wrapper around Java's ByteBuffer and Bytedeco's BytePointers. It contains a char buffer which will
  * be decoded into a Kotlin [String]. Because these are obtained from C++ they need to be de-allocated which is why
  * they provide the [dispose] method. Failing to call this method will leak memory.
+ *
+ * TODO: Test whether this works with ByteBuffers which are not coming from LLVM
  */
-public class Message(private val buffer: ByteBuffer) : Disposable, AutoCloseable {
+public class Message(private val buffer: ByteBuffer) : Disposable,
+    AutoCloseable {
     public override var valid: Boolean = true
 
     /**
@@ -41,15 +44,4 @@ public class Message(private val buffer: ByteBuffer) : Disposable, AutoCloseable
     }
 
     public override fun close() = dispose()
-
-    public companion object {
-        /**
-         * Create a new Message from a [buffer]
-         *
-         * TODO: Test whether this works with ByteBuffers which are not coming from LLVM
-         */
-        public fun create(buffer: ByteBuffer): Message {
-            return Message(buffer)
-        }
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Attribute.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Attribute.kt
@@ -5,7 +5,10 @@ import org.bytedeco.llvm.LLVM.LLVMAttributeRef
 public class Attribute internal constructor() {
     internal lateinit var ref: LLVMAttributeRef
 
-    internal constructor(attribute: LLVMAttributeRef) : this() {
+    /**
+     * TODO: Make these constructors internal (see #63)
+     */
+    public constructor(attribute: LLVMAttributeRef) : this() {
         ref = attribute
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Attribute.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Attribute.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMAttributeRef
 
-public class Attribute internal constructor(attribute: LLVMAttributeRef) {
-    internal var ref: LLVMAttributeRef = attribute
+public class Attribute internal constructor() {
+    internal lateinit var ref: LLVMAttributeRef
+
+    internal constructor(attribute: LLVMAttributeRef) : this() {
+        ref = attribute
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Attribute.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Attribute.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMAttributeRef
-import org.bytedeco.llvm.LLVM.LLVMBuilderRef
 
-public class Attribute internal constructor(internal val llvmAttribute: LLVMAttributeRef)
+public class Attribute internal constructor(attribute: LLVMAttributeRef) {
+    internal var ref: LLVMAttributeRef = attribute
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/BasicBlock.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef
 
-public class BasicBlock internal constructor(internal val llvmBlock: LLVMBasicBlockRef)
+public class BasicBlock internal constructor(block: LLVMBasicBlockRef) {
+    internal var ref: LLVMBasicBlockRef = block
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/BasicBlock.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef
 
-public class BasicBlock internal constructor(block: LLVMBasicBlockRef) {
-    internal var ref: LLVMBasicBlockRef = block
+public class BasicBlock internal constructor() {
+    internal lateinit var ref: LLVMBasicBlockRef
+
+    internal constructor(block: LLVMBasicBlockRef) : this() {
+        ref = block
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/BasicBlock.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef
 public class BasicBlock internal constructor() {
     internal lateinit var ref: LLVMBasicBlockRef
 
-    internal constructor(block: LLVMBasicBlockRef) : this() {
+    public constructor(block: LLVMBasicBlockRef) : this() {
         ref = block
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Binary.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Binary.kt
@@ -5,11 +5,14 @@ import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMBinaryRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Binary internal constructor(binary: LLVMBinaryRef) : AutoCloseable,
+public class Binary internal constructor() : AutoCloseable,
     Validatable, Disposable {
-    internal var ref: LLVMBinaryRef = binary
-
+    internal lateinit var ref: LLVMBinaryRef
     public override var valid: Boolean = true
+
+    internal constructor(binary: LLVMBinaryRef) : this() {
+        ref = binary
+    }
 
     override fun dispose() {
         require(valid) { "This binary has already been disposed." }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Binary.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Binary.kt
@@ -3,10 +3,12 @@ package dev.supergrecko.kllvm.core.typedefs
 import dev.supergrecko.kllvm.contracts.Disposable
 import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMBinaryRef
-import org.bytedeco.llvm.LLVM.LLVMPassManagerRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Binary internal constructor(internal val llvmBinary: LLVMBinaryRef) : AutoCloseable, Validatable, Disposable {
+public class Binary internal constructor(binary: LLVMBinaryRef) : AutoCloseable,
+    Validatable, Disposable {
+    internal var ref: LLVMBinaryRef = binary
+
     public override var valid: Boolean = true
 
     override fun dispose() {
@@ -14,7 +16,7 @@ public class Binary internal constructor(internal val llvmBinary: LLVMBinaryRef)
 
         valid = false
 
-        LLVM.LLVMDisposeBinary(llvmBinary)
+        LLVM.LLVMDisposeBinary(ref)
     }
 
     override fun close() = dispose()

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Binary.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Binary.kt
@@ -10,7 +10,7 @@ public class Binary internal constructor() : AutoCloseable,
     internal lateinit var ref: LLVMBinaryRef
     public override var valid: Boolean = true
 
-    internal constructor(binary: LLVMBinaryRef) : this() {
+    public constructor(binary: LLVMBinaryRef) : this() {
         ref = binary
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
@@ -8,16 +8,18 @@ import org.bytedeco.llvm.LLVM.LLVMBuilderRef
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderRef) : AutoCloseable, Validatable, Disposable {
+public class Builder internal constructor(builder: LLVMBuilderRef) :
+    AutoCloseable, Validatable, Disposable {
+    internal var ref: LLVMBuilderRef = builder
     public override var valid: Boolean = true
 
     public fun getUnderlyingRef(): LLVMBuilderRef {
-        return llvmBuilder
+        return ref
     }
 
     //region InstructionBuilders
     public fun buildRetVoid(): Value {
-        return Value(LLVM.LLVMBuildRetVoid(llvmBuilder))
+        return Value(LLVM.LLVMBuildRetVoid(ref))
     }
 
     /**
@@ -25,14 +27,14 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
      */
     public fun positionBefore(instruction: InstructionValue): Unit {
         // TODO: Test
-        LLVM.LLVMPositionBuilderBefore(getUnderlyingRef(), instruction.llvmValue)
+        LLVM.LLVMPositionBuilderBefore(getUnderlyingRef(), instruction.ref)
     }
 
     /**
      * LLVMPositionBuilderAtEnd
      */
     public fun positionAtEnd(basicBlock: BasicBlock): Unit {
-        LLVM.LLVMPositionBuilderAtEnd(getUnderlyingRef(), basicBlock.llvmBlock)
+        LLVM.LLVMPositionBuilderAtEnd(getUnderlyingRef(), basicBlock.ref)
     }
 
     /**
@@ -46,14 +48,19 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
     /**
      * LLVMClearInsertionPosition
      */
-    public fun clearInsertPosition(): Unit = LLVM.LLVMClearInsertionPosition(getUnderlyingRef())
+    public fun clearInsertPosition(): Unit =
+        LLVM.LLVMClearInsertionPosition(getUnderlyingRef())
 
     /**
      * LLVMInsertIntoBuilderWithName
      */
     public fun insert(instruction: InstructionValue, name: String?): Unit {
         // TODO: Test
-        LLVM.LLVMInsertIntoBuilderWithName(getUnderlyingRef(), instruction.getUnderlyingReference(), name)
+        LLVM.LLVMInsertIntoBuilderWithName(
+            getUnderlyingRef(),
+            instruction.getUnderlyingReference(),
+            name
+        )
     }
     /**
      * Create a function call passing in [args] and binding the result into
@@ -95,7 +102,7 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
 
         valid = false
 
-        LLVM.LLVMDisposeBuilder(llvmBuilder)
+        LLVM.LLVMDisposeBuilder(ref)
     }
 
     override fun close() = dispose()
@@ -104,7 +111,7 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
         //region InstructionBuilders
         @JvmStatic
         fun create(ctx: Context = Context.getGlobalContext()): Builder {
-            return Builder(LLVM.LLVMCreateBuilderInContext(ctx.llvmCtx))
+            return Builder(LLVM.LLVMCreateBuilderInContext(ctx.ref))
         }
 
         //endregion InstructionBuilders

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
@@ -16,7 +16,7 @@ public class Builder public constructor(context: Context = Context.getGlobalCont
         ref = LLVM.LLVMCreateBuilderInContext(context.ref)
     }
 
-    internal constructor(builder: LLVMBuilderRef) : this() {
+    public constructor(builder: LLVMBuilderRef) : this() {
         ref = builder
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
@@ -8,13 +8,16 @@ import org.bytedeco.llvm.LLVM.LLVMBuilderRef
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Builder internal constructor(builder: LLVMBuilderRef) :
-    AutoCloseable, Validatable, Disposable {
-    internal var ref: LLVMBuilderRef = builder
+public class Builder public constructor(context: Context = Context.getGlobalContext()) : AutoCloseable, Validatable, Disposable {
+    internal var ref: LLVMBuilderRef
     public override var valid: Boolean = true
 
-    public constructor(context: Context = Context.getGlobalContext()) {
+    init {
         ref = LLVM.LLVMCreateBuilderInContext(context.ref)
+    }
+
+    internal constructor(builder: LLVMBuilderRef) : this() {
+        ref = builder
     }
 
     public fun getUnderlyingRef(): LLVMBuilderRef {
@@ -66,6 +69,7 @@ public class Builder internal constructor(builder: LLVMBuilderRef) :
             name
         )
     }
+
     /**
      * Create a function call passing in [args] and binding the result into
      * variable [resultName]. Result discarded if no resultName supplied.
@@ -76,9 +80,10 @@ public class Builder internal constructor(builder: LLVMBuilderRef) :
         function: Value,
         args: List<Value>,
         resultName: String? = null
-    ) : InstructionValue {
+    ): InstructionValue {
         val argsPtr: PointerPointer<LLVMValueRef> =
-            PointerPointer(*(args.map { it.getUnderlyingReference() }.toTypedArray()))
+            PointerPointer(*(args.map { it.getUnderlyingReference() }
+                .toTypedArray()))
         val ref = LLVM.LLVMBuildCall(
             getUnderlyingRef(),
             function.getUnderlyingReference(),
@@ -97,7 +102,9 @@ public class Builder internal constructor(builder: LLVMBuilderRef) :
         return InstructionValue(
             LLVM.LLVMBuildRet(
                 getUnderlyingRef(),
-                value.getUnderlyingReference()))
+                value.getUnderlyingReference()
+            )
+        )
     }
     //endregion InstructionBuilders
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
@@ -13,6 +13,10 @@ public class Builder internal constructor(builder: LLVMBuilderRef) :
     internal var ref: LLVMBuilderRef = builder
     public override var valid: Boolean = true
 
+    public constructor(context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMCreateBuilderInContext(context.ref)
+    }
+
     public fun getUnderlyingRef(): LLVMBuilderRef {
         return ref
     }
@@ -106,15 +110,5 @@ public class Builder internal constructor(builder: LLVMBuilderRef) :
     }
 
     override fun close() = dispose()
-
-    companion object {
-        //region InstructionBuilders
-        @JvmStatic
-        fun create(ctx: Context = Context.getGlobalContext()): Builder {
-            return Builder(LLVM.LLVMCreateBuilderInContext(ctx.ref))
-        }
-
-        //endregion InstructionBuilders
-    }
 }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Builder.kt
@@ -6,16 +6,18 @@ import dev.supergrecko.kllvm.core.values.InstructionValue
 import org.bytedeco.llvm.LLVM.LLVMBuilderRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderRef) : AutoCloseable, Validatable, Disposable {
+public class Builder internal constructor(builder: LLVMBuilderRef) :
+    AutoCloseable, Validatable, Disposable {
+    internal var ref: LLVMBuilderRef = builder
     public override var valid: Boolean = true
 
     public fun getUnderlyingRef(): LLVMBuilderRef {
-        return llvmBuilder
+        return ref
     }
 
     //region InstructionBuilders
     public fun buildRetVoid(): Value {
-        return Value(LLVM.LLVMBuildRetVoid(llvmBuilder))
+        return Value(LLVM.LLVMBuildRetVoid(ref))
     }
 
     /**
@@ -23,14 +25,14 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
      */
     public fun positionBefore(instruction: InstructionValue): Unit {
         // TODO: Test
-        LLVM.LLVMPositionBuilderBefore(getUnderlyingRef(), instruction.llvmValue)
+        LLVM.LLVMPositionBuilderBefore(getUnderlyingRef(), instruction.ref)
     }
 
     /**
      * LLVMPositionBuilderAtEnd
      */
     public fun positionAtEnd(basicBlock: BasicBlock): Unit {
-        LLVM.LLVMPositionBuilderAtEnd(getUnderlyingRef(), basicBlock.llvmBlock)
+        LLVM.LLVMPositionBuilderAtEnd(getUnderlyingRef(), basicBlock.ref)
     }
 
     /**
@@ -44,14 +46,19 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
     /**
      * LLVMClearInsertionPosition
      */
-    public fun clearInsertPosition(): Unit = LLVM.LLVMClearInsertionPosition(getUnderlyingRef())
+    public fun clearInsertPosition(): Unit =
+        LLVM.LLVMClearInsertionPosition(getUnderlyingRef())
 
     /**
      * LLVMInsertIntoBuilderWithName
      */
     public fun insert(instruction: InstructionValue, name: String?): Unit {
         // TODO: Test
-        LLVM.LLVMInsertIntoBuilderWithName(getUnderlyingRef(), instruction.getUnderlyingReference(), name)
+        LLVM.LLVMInsertIntoBuilderWithName(
+            getUnderlyingRef(),
+            instruction.getUnderlyingReference(),
+            name
+        )
     }
 
     //endregion InstructionBuilders
@@ -61,7 +68,7 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
 
         valid = false
 
-        LLVM.LLVMDisposeBuilder(llvmBuilder)
+        LLVM.LLVMDisposeBuilder(ref)
     }
 
     override fun close() = dispose()
@@ -70,7 +77,7 @@ public class Builder internal constructor(internal val llvmBuilder: LLVMBuilderR
         //region InstructionBuilders
         @JvmStatic
         fun create(ctx: Context = Context.getGlobalContext()): Builder {
-            return Builder(LLVM.LLVMCreateBuilderInContext(ctx.llvmCtx))
+            return Builder(LLVM.LLVMCreateBuilderInContext(ctx.ref))
         }
 
         //endregion InstructionBuilders

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Comdat.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Comdat.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMComdat
 
-public class Comdat internal constructor(internal val llvmComdat: LLVMComdat)
+public class Comdat internal constructor(comdat: LLVMComdat) {
+    internal var ref: LLVMComdat = comdat
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Comdat.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Comdat.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMComdat
 
-public class Comdat internal constructor(comdat: LLVMComdat) {
-    internal var ref: LLVMComdat = comdat
+public class Comdat internal constructor() {
+    internal lateinit var ref: LLVMComdat
+
+    internal constructor(comdat: LLVMComdat) : this() {
+        ref = comdat
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Comdat.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Comdat.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMComdat
 public class Comdat internal constructor() {
     internal lateinit var ref: LLVMComdat
 
-    internal constructor(comdat: LLVMComdat) : this() {
+    public constructor(comdat: LLVMComdat) : this() {
         ref = comdat
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
@@ -22,6 +22,13 @@ public class Context internal constructor(ctx: LLVMContextRef) : AutoCloseable,
     internal var ref: LLVMContextRef = ctx
     public override var valid: Boolean = true
 
+    /**
+     * Create a new LLVM context
+     */
+    public constructor() {
+        ref = LLVM.LLVMContextCreate()
+    }
+
     //region Core::Context
     /**
      * Property determining whether the given context discards all value names.
@@ -165,16 +172,6 @@ public class Context internal constructor(ctx: LLVMContextRef) : AutoCloseable,
     public override fun close() = dispose()
 
     public companion object {
-        /**
-         * Create a new LLVM context
-         */
-        @JvmStatic
-        public fun create(): Context {
-            val llvmContext = LLVM.LLVMContextCreate()
-
-            return Context(llvmContext)
-        }
-
         /**
          * Obtain the global LLVM context
          */

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
@@ -16,17 +16,20 @@ import org.bytedeco.llvm.global.LLVM
  * - [Documentation](https://llvm.org/doxygen/classllvm_1_1LLVMContext.html)
  *
  * @throws IllegalArgumentException If any argument assertions fail. Most noticeably functions which involve a context ref.
+ *
+ * Note: This primary constructor is public because anyone should be able to
+ * create a context. The init block ensures the ref is valid
  */
-public class Context internal constructor(ctx: LLVMContextRef) : AutoCloseable,
-    Validatable, Disposable {
-    internal var ref: LLVMContextRef = ctx
+public class Context public constructor() : AutoCloseable, Validatable, Disposable {
+    internal var ref: LLVMContextRef
     public override var valid: Boolean = true
 
-    /**
-     * Create a new LLVM context
-     */
-    public constructor() {
+    init {
         ref = LLVM.LLVMContextCreate()
+    }
+
+    internal constructor(ctx: LLVMContextRef) : this() {
+        ref = ctx
     }
 
     //region Core::Context

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
@@ -17,7 +17,9 @@ import org.bytedeco.llvm.global.LLVM
  *
  * @throws IllegalArgumentException If any argument assertions fail. Most noticeably functions which involve a context ref.
  */
-public class Context internal constructor(internal val llvmCtx: LLVMContextRef) : AutoCloseable, Validatable, Disposable {
+public class Context internal constructor(ctx: LLVMContextRef) : AutoCloseable,
+    Validatable, Disposable {
+    internal var ref: LLVMContextRef = ctx
     public override var valid: Boolean = true
 
     //region Core::Context
@@ -35,7 +37,7 @@ public class Context internal constructor(internal val llvmCtx: LLVMContextRef) 
         get() {
             require(valid) { "This module has already been disposed." }
 
-            val willDiscard = LLVM.LLVMContextShouldDiscardValueNames(llvmCtx)
+            val willDiscard = LLVM.LLVMContextShouldDiscardValueNames(ref)
 
             // Conversion from C++ bool to kotlin Boolean
             return willDiscard.toBoolean()
@@ -46,7 +48,7 @@ public class Context internal constructor(internal val llvmCtx: LLVMContextRef) 
             // Conversion from kotlin Boolean to C++ bool
             val intValue = value.toInt()
 
-            LLVM.LLVMContextSetDiscardValueNames(llvmCtx, intValue)
+            LLVM.LLVMContextSetDiscardValueNames(ref, intValue)
         }
 
     /**
@@ -69,10 +71,13 @@ public class Context internal constructor(internal val llvmCtx: LLVMContextRef) 
      *
      * TODO: Find out how to actually call this thing from Kotlin/Java
      */
-    public fun setDiagnosticHandler(handler: LLVMDiagnosticHandler, diagnosticContext: Pointer) {
+    public fun setDiagnosticHandler(
+        handler: LLVMDiagnosticHandler,
+        diagnosticContext: Pointer
+    ) {
         require(valid) { "This module has already been disposed." }
 
-        LLVM.LLVMContextSetDiagnosticHandler(llvmCtx, handler, diagnosticContext)
+        LLVM.LLVMContextSetDiagnosticHandler(ref, handler, diagnosticContext)
     }
 
     /**
@@ -104,7 +109,7 @@ public class Context internal constructor(internal val llvmCtx: LLVMContextRef) 
     public fun getDiagnosticHandler(): LLVMDiagnosticHandler {
         require(valid) { "This module has already been disposed." }
 
-        return LLVM.LLVMContextGetDiagnosticHandler(llvmCtx)
+        return LLVM.LLVMContextGetDiagnosticHandler(ref)
     }
 
     /**
@@ -119,10 +124,13 @@ public class Context internal constructor(internal val llvmCtx: LLVMContextRef) 
      *
      * TODO: Find out how to actually call this thing from Kotlin/Java
      */
-    public fun setYieldCallback(callback: LLVMYieldCallback, opaqueHandle: Pointer) {
+    public fun setYieldCallback(
+        callback: LLVMYieldCallback,
+        opaqueHandle: Pointer
+    ) {
         require(valid) { "This module has already been disposed." }
 
-        LLVM.LLVMContextSetYieldCallback(llvmCtx, callback, opaqueHandle)
+        LLVM.LLVMContextSetYieldCallback(ref, callback, opaqueHandle)
     }
     //endregion Core::Context
 
@@ -143,7 +151,7 @@ public class Context internal constructor(internal val llvmCtx: LLVMContextRef) 
 
         valid = false
 
-        LLVM.LLVMContextDispose(llvmCtx)
+        LLVM.LLVMContextDispose(ref)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Context.kt
@@ -28,7 +28,7 @@ public class Context public constructor() : AutoCloseable, Validatable, Disposab
         ref = LLVM.LLVMContextCreate()
     }
 
-    internal constructor(ctx: LLVMContextRef) : this() {
+    public constructor(ctx: LLVMContextRef) : this() {
         ref = ctx
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/DiagnosticInfo.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/DiagnosticInfo.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMDiagnosticInfoRef
 public class DiagnosticInfo internal constructor() {
     internal lateinit var ref: LLVMDiagnosticInfoRef
 
-    internal constructor(info: LLVMDiagnosticInfoRef) : this() {
+    public constructor(info: LLVMDiagnosticInfoRef) : this() {
         ref = info
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/DiagnosticInfo.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/DiagnosticInfo.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMDiagnosticInfoRef
 
-public class DiagnosticInfo internal constructor(info: LLVMDiagnosticInfoRef) {
-    internal var ref: LLVMDiagnosticInfoRef = info
+public class DiagnosticInfo internal constructor() {
+    internal lateinit var ref: LLVMDiagnosticInfoRef
+
+    internal constructor(info: LLVMDiagnosticInfoRef) : this() {
+        ref = info
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/DiagnosticInfo.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/DiagnosticInfo.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMDiagnosticInfoRef
 
-public class DiagnosticInfo internal constructor(internal val llvmDiagnosticInfo: LLVMDiagnosticInfoRef)
+public class DiagnosticInfo internal constructor(info: LLVMDiagnosticInfoRef) {
+    internal var ref: LLVMDiagnosticInfoRef = info
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/JitEventListener.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/JitEventListener.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMJITEventListenerRef
 
-public class JitEventListener internal constructor(internal val llvmListener: LLVMJITEventListenerRef)
+public class JitEventListener internal constructor(listener: LLVMJITEventListenerRef) {
+    internal var ref: LLVMJITEventListenerRef = listener
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/JitEventListener.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/JitEventListener.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMJITEventListenerRef
 public class JitEventListener internal constructor() {
     internal lateinit var ref: LLVMJITEventListenerRef
 
-    internal constructor(listener: LLVMJITEventListenerRef) : this() {
+    public constructor(listener: LLVMJITEventListenerRef) : this() {
         ref = listener
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/JitEventListener.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/JitEventListener.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMJITEventListenerRef
 
-public class JitEventListener internal constructor(listener: LLVMJITEventListenerRef) {
-    internal var ref: LLVMJITEventListenerRef = listener
+public class JitEventListener internal constructor() {
+    internal lateinit var ref: LLVMJITEventListenerRef
+
+    internal constructor(listener: LLVMJITEventListenerRef) : this() {
+        ref = listener
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/MemoryBuffer.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/MemoryBuffer.kt
@@ -5,10 +5,14 @@ import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMMemoryBufferRef
 import org.bytedeco.llvm.global.LLVM
 
-public class MemoryBuffer internal constructor(buffer: LLVMMemoryBufferRef) :
+public class MemoryBuffer internal constructor() :
     AutoCloseable, Validatable, Disposable {
-    internal var ref: LLVMMemoryBufferRef = buffer
+    internal lateinit var ref: LLVMMemoryBufferRef
     public override var valid: Boolean = true
+
+    internal constructor(buffer: LLVMMemoryBufferRef) : this() {
+        ref = buffer
+    }
 
     override fun dispose() {
         require(valid) { "This buffer has already been disposed." }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/MemoryBuffer.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/MemoryBuffer.kt
@@ -10,7 +10,7 @@ public class MemoryBuffer internal constructor() :
     internal lateinit var ref: LLVMMemoryBufferRef
     public override var valid: Boolean = true
 
-    internal constructor(buffer: LLVMMemoryBufferRef) : this() {
+    public constructor(buffer: LLVMMemoryBufferRef) : this() {
         ref = buffer
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/MemoryBuffer.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/MemoryBuffer.kt
@@ -5,7 +5,9 @@ import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMMemoryBufferRef
 import org.bytedeco.llvm.global.LLVM
 
-public class MemoryBuffer internal constructor(internal val llvmBuffer: LLVMMemoryBufferRef) : AutoCloseable, Validatable, Disposable {
+public class MemoryBuffer internal constructor(buffer: LLVMMemoryBufferRef) :
+    AutoCloseable, Validatable, Disposable {
+    internal var ref: LLVMMemoryBufferRef = buffer
     public override var valid: Boolean = true
 
     override fun dispose() {
@@ -13,7 +15,7 @@ public class MemoryBuffer internal constructor(internal val llvmBuffer: LLVMMemo
 
         valid = false
 
-        LLVM.LLVMDisposeMemoryBuffer(llvmBuffer)
+        LLVM.LLVMDisposeMemoryBuffer(ref)
     }
 
     override fun close() = dispose()

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Metadata.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Metadata.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMMetadataRef
 public class Metadata internal constructor() {
     internal lateinit var ref: LLVMMetadataRef
 
-    internal constructor(metadata: LLVMMetadataRef) : this() {
+    public constructor(metadata: LLVMMetadataRef) : this() {
         ref = metadata
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Metadata.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Metadata.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMMetadataRef
 
-public class Metadata internal constructor(metadata: LLVMMetadataRef) {
-    internal var ref: LLVMMetadataRef = metadata
+public class Metadata internal constructor() {
+    internal lateinit var ref: LLVMMetadataRef
+
+    internal constructor(metadata: LLVMMetadataRef) : this() {
+        ref = metadata
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Metadata.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Metadata.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMMetadataRef
 
-public class Metadata internal constructor(internal val llvmMetadata: LLVMMetadataRef)
+public class Metadata internal constructor(metadata: LLVMMetadataRef) {
+    internal var ref: LLVMMetadataRef = metadata
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
@@ -8,12 +8,16 @@ import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMModuleRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Module internal constructor(module: LLVMModuleRef) : AutoCloseable,
+public class Module internal constructor() : AutoCloseable,
     Validatable, Disposable {
-    internal var ref: LLVMModuleRef = module
+    internal lateinit var ref: LLVMModuleRef
     public override var valid: Boolean = true
 
-    public constructor(sourceFileName: String, context: Context = Context.getGlobalContext()) {
+    internal constructor(module: LLVMModuleRef) : this() {
+        ref = module
+    }
+
+    public constructor(sourceFileName: String, context: Context = Context.getGlobalContext()) : this() {
         ref = LLVM.LLVMModuleCreateWithNameInContext(sourceFileName, context.ref)
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
@@ -13,7 +13,7 @@ public class Module internal constructor() : AutoCloseable,
     internal lateinit var ref: LLVMModuleRef
     public override var valid: Boolean = true
 
-    internal constructor(module: LLVMModuleRef) : this() {
+    public constructor(module: LLVMModuleRef) : this() {
         ref = module
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
@@ -13,6 +13,10 @@ public class Module internal constructor(module: LLVMModuleRef) : AutoCloseable,
     internal var ref: LLVMModuleRef = module
     public override var valid: Boolean = true
 
+    public constructor(sourceFileName: String, context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMModuleCreateWithNameInContext(sourceFileName, context.ref)
+    }
+
     //region Core::Modules
     public fun dump() {
         // TODO: test
@@ -77,21 +81,4 @@ public class Module internal constructor(module: LLVMModuleRef) : AutoCloseable,
     public override fun close() = dispose()
 
     public fun getUnderlyingReference() = ref
-
-    public companion object {
-        //region Core::Modules
-        @JvmStatic
-        public fun create(
-            sourceFileName: String,
-            context: Context = Context.getGlobalContext()
-        ): Module {
-            return Module(
-                LLVM.LLVMModuleCreateWithNameInContext(
-                    sourceFileName,
-                    context.ref
-                )
-            )
-        }
-        //endregion Core::Modules
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Module.kt
@@ -4,51 +4,57 @@ import dev.supergrecko.kllvm.contracts.Disposable
 import dev.supergrecko.kllvm.contracts.Validatable
 import dev.supergrecko.kllvm.core.types.FunctionType
 import dev.supergrecko.kllvm.core.values.FunctionValue
-import org.bytedeco.javacpp.Pointer
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMModuleRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Module internal constructor(internal val llvmModule: LLVMModuleRef) : AutoCloseable, Validatable, Disposable {
+public class Module internal constructor(module: LLVMModuleRef) : AutoCloseable,
+    Validatable, Disposable {
+    internal var ref: LLVMModuleRef = module
     public override var valid: Boolean = true
 
     //region Core::Modules
     public fun dump() {
         // TODO: test
-        LLVM.LLVMDumpModule(llvmModule)
+        LLVM.LLVMDumpModule(ref)
     }
 
     public fun addFunction(name: String, type: FunctionType): FunctionValue {
         // TODO: test
-        val value = LLVM.LLVMAddFunction(llvmModule, name, type.getUnderlyingReference())
+        val value =
+            LLVM.LLVMAddFunction(ref, name, type.getUnderlyingReference())
 
         return FunctionValue(value)
     }
 
     public fun clone(): Module {
-        val mod = LLVM.LLVMCloneModule(llvmModule)
+        val mod = LLVM.LLVMCloneModule(ref)
 
         return Module(mod)
     }
 
     public fun getModuleIdentifier(): String {
-        val ptr = LLVM.LLVMGetModuleIdentifier(llvmModule, SizeTPointer(0))
+        val ptr = LLVM.LLVMGetModuleIdentifier(ref, SizeTPointer(0))
 
         return ptr.string
     }
 
     public fun setModuleIdentifier(identifier: String) {
-        LLVM.LLVMSetModuleIdentifier(llvmModule, identifier, identifier.length.toLong())
+        LLVM.LLVMSetModuleIdentifier(
+            ref,
+            identifier,
+            identifier.length.toLong()
+        )
     }
 
     public fun getSourceFileName(): String {
-        val ptr = LLVM.LLVMGetSourceFileName(llvmModule, SizeTPointer(0))
+        val ptr = LLVM.LLVMGetSourceFileName(ref, SizeTPointer(0))
 
         return ptr.string
     }
 
     public fun setSourceFileName(sourceName: String) {
-        LLVM.LLVMSetSourceFileName(llvmModule, sourceName, sourceName.length.toLong())
+        LLVM.LLVMSetSourceFileName(ref, sourceName, sourceName.length.toLong())
     }
 
     public fun getFunction(name: String): Value? {
@@ -65,18 +71,26 @@ public class Module internal constructor(internal val llvmModule: LLVMModuleRef)
 
         valid = false
 
-        LLVM.LLVMDisposeModule(llvmModule)
+        LLVM.LLVMDisposeModule(ref)
     }
 
     public override fun close() = dispose()
 
-    public fun getUnderlyingReference() = llvmModule
+    public fun getUnderlyingReference() = ref
 
     public companion object {
         //region Core::Modules
         @JvmStatic
-        public fun create(sourceFileName: String, context: Context = Context.getGlobalContext()): Module {
-            return Module(LLVM.LLVMModuleCreateWithNameInContext(sourceFileName, context.llvmCtx))
+        public fun create(
+            sourceFileName: String,
+            context: Context = Context.getGlobalContext()
+        ): Module {
+            return Module(
+                LLVM.LLVMModuleCreateWithNameInContext(
+                    sourceFileName,
+                    context.ref
+                )
+            )
         }
         //endregion Core::Modules
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/ModuleProvider.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/ModuleProvider.kt
@@ -10,7 +10,7 @@ public class ModuleProvider internal constructor() :
     internal lateinit var ref: LLVMModuleProviderRef
     public override var valid: Boolean = true
 
-    internal constructor(provider: LLVMModuleProviderRef) : this() {
+    public constructor(provider: LLVMModuleProviderRef) : this() {
         ref = provider
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/ModuleProvider.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/ModuleProvider.kt
@@ -5,7 +5,9 @@ import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMModuleProviderRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ModuleProvider internal constructor(internal val llvmModuleProvider: LLVMModuleProviderRef) : AutoCloseable, Validatable, Disposable {
+public class ModuleProvider internal constructor(provider: LLVMModuleProviderRef) :
+    AutoCloseable, Validatable, Disposable {
+    internal var ref: LLVMModuleProviderRef = provider
     public override var valid: Boolean = true
 
     override fun dispose() {
@@ -13,7 +15,7 @@ public class ModuleProvider internal constructor(internal val llvmModuleProvider
 
         valid = false
 
-        LLVM.LLVMDisposeModuleProvider(llvmModuleProvider)
+        LLVM.LLVMDisposeModuleProvider(ref)
     }
 
     override fun close() = dispose()

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/ModuleProvider.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/ModuleProvider.kt
@@ -5,10 +5,14 @@ import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMModuleProviderRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ModuleProvider internal constructor(provider: LLVMModuleProviderRef) :
+public class ModuleProvider internal constructor() :
     AutoCloseable, Validatable, Disposable {
-    internal var ref: LLVMModuleProviderRef = provider
+    internal lateinit var ref: LLVMModuleProviderRef
     public override var valid: Boolean = true
+
+    internal constructor(provider: LLVMModuleProviderRef) : this() {
+        ref = provider
+    }
 
     override fun dispose() {
         require(valid) { "This module has already been disposed." }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/NamedMetadataNode.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/NamedMetadataNode.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMNamedMDNodeRef
 
-public class NamedMetadataNode internal constructor(internal val llvmNamedMetadata: LLVMNamedMDNodeRef)
+public class NamedMetadataNode internal constructor(node: LLVMNamedMDNodeRef) {
+    internal var ref: LLVMNamedMDNodeRef = node
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/NamedMetadataNode.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/NamedMetadataNode.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMNamedMDNodeRef
 public class NamedMetadataNode internal constructor() {
     internal lateinit var ref: LLVMNamedMDNodeRef
 
-    internal constructor(node: LLVMNamedMDNodeRef) : this() {
+    public constructor(node: LLVMNamedMDNodeRef) : this() {
         ref = node
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/NamedMetadataNode.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/NamedMetadataNode.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMNamedMDNodeRef
 
-public class NamedMetadataNode internal constructor(node: LLVMNamedMDNodeRef) {
-    internal var ref: LLVMNamedMDNodeRef = node
+public class NamedMetadataNode internal constructor() {
+    internal lateinit var ref: LLVMNamedMDNodeRef
+
+    internal constructor(node: LLVMNamedMDNodeRef) : this() {
+        ref = node
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassManager.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassManager.kt
@@ -5,10 +5,14 @@ import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMPassManagerRef
 import org.bytedeco.llvm.global.LLVM
 
-public class PassManager internal constructor(pass: LLVMPassManagerRef) :
+public class PassManager internal constructor() :
     AutoCloseable, Validatable, Disposable {
-    internal var ref: LLVMPassManagerRef = pass
+    internal lateinit var ref: LLVMPassManagerRef
     public override var valid: Boolean = true
+
+    internal constructor(pass: LLVMPassManagerRef) : this() {
+        ref = pass
+    }
 
     override fun dispose() {
         require(valid) { "This module has already been disposed." }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassManager.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassManager.kt
@@ -5,7 +5,9 @@ import dev.supergrecko.kllvm.contracts.Validatable
 import org.bytedeco.llvm.LLVM.LLVMPassManagerRef
 import org.bytedeco.llvm.global.LLVM
 
-public class PassManager internal constructor(internal val llvmPass: LLVMPassManagerRef) : AutoCloseable, Validatable, Disposable {
+public class PassManager internal constructor(pass: LLVMPassManagerRef) :
+    AutoCloseable, Validatable, Disposable {
+    internal var ref: LLVMPassManagerRef = pass
     public override var valid: Boolean = true
 
     override fun dispose() {
@@ -13,7 +15,7 @@ public class PassManager internal constructor(internal val llvmPass: LLVMPassMan
 
         valid = false
 
-        LLVM.LLVMDisposePassManager(llvmPass)
+        LLVM.LLVMDisposePassManager(ref)
     }
 
     override fun close() = dispose()

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassManager.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassManager.kt
@@ -10,7 +10,7 @@ public class PassManager internal constructor() :
     internal lateinit var ref: LLVMPassManagerRef
     public override var valid: Boolean = true
 
-    internal constructor(pass: LLVMPassManagerRef) : this() {
+    public constructor(pass: LLVMPassManagerRef) : this() {
         ref = pass
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassRegistry.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassRegistry.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMPassRegistryRef
 public class PassRegistry internal constructor() {
     internal lateinit var ref: LLVMPassRegistryRef
 
-    internal constructor(registry: LLVMPassRegistryRef) : this() {
+    public constructor(registry: LLVMPassRegistryRef) : this() {
         ref = registry
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassRegistry.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassRegistry.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMPassRegistryRef
 
-public class PassRegistry internal constructor(registry: LLVMPassRegistryRef) {
-    internal var ref: LLVMPassRegistryRef = registry
+public class PassRegistry internal constructor() {
+    internal lateinit var ref: LLVMPassRegistryRef
+
+    internal constructor(registry: LLVMPassRegistryRef) : this() {
+        ref = registry
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassRegistry.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/PassRegistry.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMPassRegistryRef
 
-public class PassRegistry internal constructor(internal val llvmRegistry: LLVMPassRegistryRef)
+public class PassRegistry internal constructor(registry: LLVMPassRegistryRef) {
+    internal var ref: LLVMPassRegistryRef = registry
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
@@ -10,7 +10,7 @@ import org.bytedeco.llvm.global.LLVM
 public open class Type internal constructor() {
     internal lateinit var ref: LLVMTypeRef
 
-    internal constructor(ty: LLVMTypeRef) : this() {
+    public constructor(ty: LLVMTypeRef) : this() {
         ref = ty
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
@@ -7,8 +7,12 @@ import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public open class Type internal constructor(ty: LLVMTypeRef) {
-    internal var ref: LLVMTypeRef = ty
+public open class Type internal constructor() {
+    internal lateinit var ref: LLVMTypeRef
+
+    internal constructor(ty: LLVMTypeRef) : this() {
+        ref = ty
+    }
 
     public constructor(type: Type) : this(type.ref)
 
@@ -80,11 +84,11 @@ public open class Type internal constructor(ty: LLVMTypeRef) {
 
     //region Typecasting
     public fun toPointerType(addressSpace: Int = 0): PointerType =
-        PointerType.new(this, addressSpace)
+        PointerType(this, addressSpace)
 
-    public fun toArrayType(size: Int): ArrayType = ArrayType.new(this, size)
+    public fun toArrayType(size: Int): ArrayType = ArrayType(this, size)
 
-    public fun toVectorType(size: Int): VectorType = VectorType.new(this, size)
+    public fun toVectorType(size: Int): VectorType = VectorType(this, size)
     //endregion Typecasting
 
     public fun getUnderlyingReference(): LLVMTypeRef = ref

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
@@ -8,9 +8,8 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 import java.lang.reflect.Constructor
 
-public open class Type internal constructor(
-        internal val llvmType: LLVMTypeRef
-) {
+public open class Type internal constructor(ref: LLVMTypeRef) {
+    internal var llvmType: LLVMTypeRef = ref
     //region Core::Types
     /**
      * @see [LLVM.LLVMGetTypeKind]
@@ -78,18 +77,20 @@ public open class Type internal constructor(
     //endregion Core::Values::Constants
 
     //region Typecasting
-    public fun toPointerType(addressSpace: Int = 0): PointerType = PointerType.new(this, addressSpace)
+    public fun toPointerType(addressSpace: Int = 0): PointerType =
+        PointerType.new(this, addressSpace)
 
     public fun toArrayType(size: Int): ArrayType = ArrayType.new(this, size)
 
     public fun toVectorType(size: Int): VectorType = VectorType.new(this, size)
 
     public inline fun <reified T : Type> cast(): T {
-        val ctor: Constructor<T> = T::class.java.getDeclaredConstructor(LLVMTypeRef::class.java)
+        val ctor: Constructor<T> =
+            T::class.java.getDeclaredConstructor(LLVMTypeRef::class.java)
 
         return ctor.newInstance(getUnderlyingReference())
-                // Should theoretically be unreachable
-                ?: throw TypeCastException("Failed to cast LLVMType to T")
+        // Should theoretically be unreachable
+            ?: throw TypeCastException("Failed to cast LLVMType to T")
     }
 
     public fun asArrayType(): ArrayType = ArrayType(llvmType)
@@ -115,9 +116,9 @@ public open class Type internal constructor(
             val kind = LLVM.LLVMGetTypeKind(type)
 
             return TypeKind.values()
-                    .firstOrNull { it.value == kind }
+                .firstOrNull { it.value == kind }
             // Theoretically unreachable, but kept if wrong LLVM version is used
-                    ?: throw IllegalArgumentException("Type $type has invalid type kind")
+                ?: throw IllegalArgumentException("Type $type has invalid type kind")
         }
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Use.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Use.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMUseRef
 public class Use internal constructor() {
     internal lateinit var ref: LLVMUseRef
 
-    internal constructor(use: LLVMUseRef) : this() {
+    public constructor(use: LLVMUseRef) : this() {
         ref = use
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Use.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Use.kt
@@ -2,4 +2,6 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMUseRef
 
-public class Use internal constructor(internal val llvmUse: LLVMUseRef)
+public class Use internal constructor(use: LLVMUseRef) {
+    internal var ref: LLVMUseRef = use
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Use.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Use.kt
@@ -2,6 +2,10 @@ package dev.supergrecko.kllvm.core.typedefs
 
 import org.bytedeco.llvm.LLVM.LLVMUseRef
 
-public class Use internal constructor(use: LLVMUseRef) {
-    internal var ref: LLVMUseRef = use
+public class Use internal constructor() {
+    internal lateinit var ref: LLVMUseRef
+
+    internal constructor(use: LLVMUseRef) : this() {
+        ref = use
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
@@ -14,6 +14,9 @@ public open class Value internal constructor(
     value: LLVMValueRef
 ) {
     internal var ref: LLVMValueRef = value
+
+    public constructor(value: Value) : this(value.ref)
+
     //region Core::Values::Constants::GlobalVariables
     /**
      * @see [LLVM.LLVMIsExternallyInitialized]
@@ -140,16 +143,6 @@ public open class Value internal constructor(
         return LLVM.LLVMIsNull(ref).toBoolean()
     }
     //endregion Core::Values::Constants
-
-    //region Typecasting
-    public inline fun <reified T : Value> cast(): T {
-        val ctor: Constructor<T> =
-            T::class.java.getDeclaredConstructor(LLVMValueRef::class.java)
-
-        return ctor.newInstance(getUnderlyingReference())
-            ?: throw TypeCastException("Failed to cast LLVMType to T")
-    }
-    //endregion Typecasting
 
     public fun getUnderlyingReference(): LLVMValueRef = ref
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
@@ -11,32 +11,33 @@ import org.bytedeco.llvm.global.LLVM
 import java.lang.reflect.Constructor
 
 public open class Value internal constructor(
-        internal val llvmValue: LLVMValueRef
+    value: LLVMValueRef
 ) {
+    internal var ref: LLVMValueRef = value
     //region Core::Values::Constants::GlobalVariables
     /**
      * @see [LLVM.LLVMIsExternallyInitialized]
      * @see [LLVM.LLVMSetExternallyInitialized]
      */
     public var externallyInitialized: Boolean
-        get() = LLVM.LLVMIsExternallyInitialized(llvmValue).toBoolean()
-        set(value) = LLVM.LLVMSetExternallyInitialized(llvmValue, value.toInt())
+        get() = LLVM.LLVMIsExternallyInitialized(ref).toBoolean()
+        set(value) = LLVM.LLVMSetExternallyInitialized(ref, value.toInt())
 
     /**
      * @see [LLVM.LLVMGetInitializer]
      * @see [LLVM.LLVMSetInitializer]
      */
     public var initializer: Value
-        get() = Value(LLVM.LLVMGetInitializer(llvmValue))
-        set(value) = LLVM.LLVMSetInitializer(llvmValue, value.llvmValue)
+        get() = Value(LLVM.LLVMGetInitializer(ref))
+        set(value) = LLVM.LLVMSetInitializer(ref, value.ref)
 
     /**
      * @see [LLVM.LLVMIsGlobalConstant]
      * @see [LLVM.LLVMSetGlobalConstant]
      */
     public var globalConstant: Boolean
-        get() = LLVM.LLVMIsGlobalConstant(llvmValue).toBoolean()
-        set(value) = LLVM.LLVMSetGlobalConstant(llvmValue, value.toInt())
+        get() = LLVM.LLVMIsGlobalConstant(ref).toBoolean()
+        set(value) = LLVM.LLVMSetGlobalConstant(ref, value.toInt())
 
     /**
      * @see [LLVM.LLVMSetThreadLocalMode]
@@ -44,21 +45,21 @@ public open class Value internal constructor(
      */
     public var threadLocalMode: ThreadLocalMode
         get() {
-            val mode = LLVM.LLVMGetThreadLocalMode(llvmValue)
+            val mode = LLVM.LLVMGetThreadLocalMode(ref)
 
             return ThreadLocalMode.values()
-                    .firstOrNull { it.value == mode }
-                    ?: throw Unreachable()
+                .firstOrNull { it.value == mode }
+                ?: throw Unreachable()
         }
-        set(value) = LLVM.LLVMSetThreadLocalMode(llvmValue, value.value)
+        set(value) = LLVM.LLVMSetThreadLocalMode(ref, value.value)
 
     /**
      * @see [LLVM.LLVMSetThreadLocal]
      * @see [LLVM.LLVMIsThreadLocal]
      */
     public var threadLocal: Boolean
-        get() = LLVM.LLVMIsThreadLocal(llvmValue).toBoolean()
-        set(value) = LLVM.LLVMSetThreadLocal(llvmValue, value.toInt())
+        get() = LLVM.LLVMIsThreadLocal(ref).toBoolean()
+        set(value) = LLVM.LLVMSetThreadLocal(ref, value.toInt())
     //endregion Core::Values::Constants::GlobalVariables
 
     //region Core::Values::Constants::GeneralAPIs
@@ -68,18 +69,18 @@ public open class Value internal constructor(
      */
     public var valueName: String
         get() {
-            val ptr = LLVM.LLVMGetValueName2(llvmValue, SizeTPointer(0))
+            val ptr = LLVM.LLVMGetValueName2(ref, SizeTPointer(0))
 
             return ptr.string
         }
-        set(value) = LLVM.LLVMSetValueName2(llvmValue, value, value.length.toLong())
+        set(value) = LLVM.LLVMSetValueName2(ref, value, value.length.toLong())
 
     // TODO: Should these be properties?
     /**
      * @see [LLVM.LLVMTypeOf]
      */
     public fun getType(): Type {
-        val type = LLVM.LLVMTypeOf(llvmValue)
+        val type = LLVM.LLVMTypeOf(ref)
 
         return Type(type)
     }
@@ -88,33 +89,33 @@ public open class Value internal constructor(
      * @see [LLVM.LLVMIsUndef]
      */
     public fun isUndef(): Boolean {
-        return LLVM.LLVMIsUndef(llvmValue).toBoolean()
+        return LLVM.LLVMIsUndef(ref).toBoolean()
     }
 
     /**
      * @see [LLVM.LLVMIsConstant]
      */
     public fun isConstant(): Boolean {
-        return LLVM.LLVMIsConstant(llvmValue).toBoolean()
+        return LLVM.LLVMIsConstant(ref).toBoolean()
     }
 
     /**
      * @see [LLVM.LLVMGetValueKind]
      */
-    public fun getValueKind(): ValueKind = getValueKind(llvmValue)
+    public fun getValueKind(): ValueKind = getValueKind(ref)
 
     /**
      * @see [LLVM.LLVMDumpValue]
      */
     public fun dump() {
-        LLVM.LLVMDumpValue(llvmValue)
+        LLVM.LLVMDumpValue(ref)
     }
 
     /**
      * @see [LLVM.LLVMPrintValueToString]
      */
     public fun dumpToString(): String {
-        val ptr = LLVM.LLVMPrintValueToString(llvmValue)
+        val ptr = LLVM.LLVMPrintValueToString(ref)
 
         return ptr.string
     }
@@ -123,7 +124,7 @@ public open class Value internal constructor(
      * @see [LLVM.LLVMReplaceAllUsesWith]
      */
     public fun replaceAllUsesWith(value: Value) {
-        LLVM.LLVMReplaceAllUsesWith(llvmValue, value.llvmValue)
+        LLVM.LLVMReplaceAllUsesWith(ref, value.ref)
     }
 
     // TODO: Implement these two
@@ -136,20 +137,21 @@ public open class Value internal constructor(
      * @see [LLVM.LLVMIsNull]
      */
     public fun isNull(): Boolean {
-        return LLVM.LLVMIsNull(llvmValue).toBoolean()
+        return LLVM.LLVMIsNull(ref).toBoolean()
     }
     //endregion Core::Values::Constants
 
     //region Typecasting
     public inline fun <reified T : Value> cast(): T {
-        val ctor: Constructor<T> = T::class.java.getDeclaredConstructor(LLVMValueRef::class.java)
+        val ctor: Constructor<T> =
+            T::class.java.getDeclaredConstructor(LLVMValueRef::class.java)
 
         return ctor.newInstance(getUnderlyingReference())
-                ?: throw TypeCastException("Failed to cast LLVMType to T")
+            ?: throw TypeCastException("Failed to cast LLVMType to T")
     }
     //endregion Typecasting
 
-    public fun getUnderlyingReference(): LLVMValueRef = llvmValue
+    public fun getUnderlyingReference(): LLVMValueRef = ref
 
     public companion object {
         /**
@@ -162,9 +164,9 @@ public open class Value internal constructor(
             val kind = LLVM.LLVMGetValueKind(value)
 
             return ValueKind.values()
-                    .firstOrNull { it.value == kind }
+                .firstOrNull { it.value == kind }
             // Theoretically unreachable, but kept if wrong LLVM version is used
-                    ?: throw IllegalArgumentException("Value $value has invalid value kind")
+                ?: throw IllegalArgumentException("Value $value has invalid value kind")
         }
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
@@ -8,12 +8,13 @@ import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
-import java.lang.reflect.Constructor
 
-public open class Value internal constructor(
-    value: LLVMValueRef
-) {
-    internal var ref: LLVMValueRef = value
+public open class Value internal constructor() {
+    internal lateinit var ref: LLVMValueRef
+
+    internal constructor(value: LLVMValueRef) : this() {
+        ref = value
+    }
 
     public constructor(value: Value) : this(value.ref)
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
@@ -12,7 +12,7 @@ import org.bytedeco.llvm.global.LLVM
 public open class Value internal constructor() {
     internal lateinit var ref: LLVMValueRef
 
-    internal constructor(value: LLVMValueRef) : this() {
+    public constructor(value: LLVMValueRef) : this() {
         ref = value
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
@@ -11,6 +11,19 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
+    public constructor(type: Type) : this(type.ref)
+
+    /**
+     * Create an array type
+     *
+     * Constructs an array of type [type] with size [size].
+     */
+    public constructor(type: Type, size: Int) {
+        require(size >= 0) { "Cannot make array of negative size" }
+
+        ref = LLVM.LLVMArrayType(type.ref, size)
+    }
+
     //region Core::Types::SequentialTypes
     /**
      * Returns the amount of elements contained in this type
@@ -18,7 +31,7 @@ public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
      * This is shared with [ArrayType], [VectorType], [PointerType]
      */
     public fun getElementCount(): Int {
-        return LLVM.LLVMGetArrayLength(llvmType)
+        return LLVM.LLVMGetArrayLength(ref)
     }
 
     /**
@@ -29,7 +42,7 @@ public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
     @Shared
     public fun getSubtypes(): List<Type> {
         val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
-        LLVM.LLVMGetSubtypes(llvmType, dest)
+        LLVM.LLVMGetSubtypes(ref, dest)
 
         return dest.iterateIntoType { Type(it) }
     }
@@ -41,7 +54,7 @@ public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
      */
     @Shared
     public fun getElementType(): Type {
-        val type = LLVM.LLVMGetElementType(llvmType)
+        val type = LLVM.LLVMGetElementType(ref)
 
         return Type(type)
     }
@@ -54,18 +67,4 @@ public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
         return ArrayValue(str)
     }
     //endregion Core::Values::Constants::CompositeConstants
-
-    public companion object {
-        /**
-         * Create an array type
-         *
-         * Constructs an array of type [type] with size [size].
-         */
-        @JvmStatic
-        public fun new(type: Type, size: Int): ArrayType {
-            require(size >= 0) { "Cannot make array of negative size" }
-
-            return ArrayType(LLVM.LLVMArrayType(type.llvmType, size))
-        }
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
@@ -1,16 +1,17 @@
 package dev.supergrecko.kllvm.core.types
 
 import dev.supergrecko.kllvm.annotations.Shared
-import dev.supergrecko.kllvm.core.typedefs.Context
 import dev.supergrecko.kllvm.core.typedefs.Type
-import dev.supergrecko.kllvm.core.values.ArrayValue
 import dev.supergrecko.kllvm.utils.iterateIntoType
-import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
+public class ArrayType internal constructor() : Type() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
     public constructor(type: Type) : this(type.ref)
 
     /**
@@ -18,7 +19,7 @@ public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
      *
      * Constructs an array of type [type] with size [size].
      */
-    public constructor(type: Type, size: Int) {
+    public constructor(type: Type, size: Int) : this() {
         require(size >= 0) { "Cannot make array of negative size" }
 
         ref = LLVM.LLVMArrayType(type.ref, size)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
@@ -49,7 +49,7 @@ public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
 
     //region Core::Values::Constants::CompositeConstants
     public fun getConstString(content: String, nullTerminate: Boolean, context: Context = Context.getGlobalContext()): ArrayValue {
-        val str = LLVM.LLVMConstStringInContext(context.llvmCtx, content, content.length, nullTerminate.toInt())
+        val str = LLVM.LLVMConstStringInContext(context.ref, content, content.length, nullTerminate.toInt())
 
         return ArrayValue(str)
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/ArrayType.kt
@@ -59,12 +59,4 @@ public class ArrayType(llvmType: LLVMTypeRef) : Type(llvmType) {
         return Type(type)
     }
     //endregion Core::Types::SequentialTypes
-
-    //region Core::Values::Constants::CompositeConstants
-    public fun getConstString(content: String, nullTerminate: Boolean, context: Context = Context.getGlobalContext()): ArrayValue {
-        val str = LLVM.LLVMConstStringInContext(context.ref, content, content.length, nullTerminate.toInt())
-
-        return ArrayValue(str)
-    }
-    //endregion Core::Values::Constants::CompositeConstants
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
@@ -23,12 +23,12 @@ public class FloatType(llvmType: LLVMTypeRef) : Type(llvmType) {
         @JvmStatic
         public fun new(kind: TypeKind, ctx: Context = Context.getGlobalContext()): FloatType {
             val type = when (kind) {
-                TypeKind.Half -> LLVM.LLVMHalfTypeInContext(ctx.llvmCtx)
-                TypeKind.Float -> LLVM.LLVMFloatTypeInContext(ctx.llvmCtx)
-                TypeKind.Double -> LLVM.LLVMDoubleTypeInContext(ctx.llvmCtx)
-                TypeKind.X86_FP80 -> LLVM.LLVMX86FP80TypeInContext(ctx.llvmCtx)
-                TypeKind.FP128 -> LLVM.LLVMFP128TypeInContext(ctx.llvmCtx)
-                TypeKind.PPC_FP128 -> LLVM.LLVMPPCFP128TypeInContext(ctx.llvmCtx)
+                TypeKind.Half -> LLVM.LLVMHalfTypeInContext(ctx.ref)
+                TypeKind.Float -> LLVM.LLVMFloatTypeInContext(ctx.ref)
+                TypeKind.Double -> LLVM.LLVMDoubleTypeInContext(ctx.ref)
+                TypeKind.X86_FP80 -> LLVM.LLVMX86FP80TypeInContext(ctx.ref)
+                TypeKind.FP128 -> LLVM.LLVMFP128TypeInContext(ctx.ref)
+                TypeKind.PPC_FP128 -> LLVM.LLVMPPCFP128TypeInContext(ctx.ref)
                 else -> {
                     throw IllegalArgumentException("Type kind '$kind' is not a floating point type")
                 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
@@ -27,10 +27,4 @@ public class FloatType(llvmType: LLVMTypeRef) : Type(llvmType) {
             else -> throw Unreachable()
         }
     }
-
-    //region Core::Values::Constants::ScalarConstants
-    public fun getConstantFloat(value: Double): FloatValue {
-        return FloatValue(LLVM.LLVMConstReal(ref, value))
-    }
-    //endregion Core::Values::Constants::ScalarConstants
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
@@ -4,11 +4,14 @@ import dev.supergrecko.kllvm.contracts.Unreachable
 import dev.supergrecko.kllvm.core.enumerations.TypeKind
 import dev.supergrecko.kllvm.core.typedefs.Context
 import dev.supergrecko.kllvm.core.typedefs.Type
-import dev.supergrecko.kllvm.core.values.FloatValue
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class FloatType(llvmType: LLVMTypeRef) : Type(llvmType) {
+public class FloatType internal constructor() : Type() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
     public constructor(type: Type) : this(type.ref)
 
     /**
@@ -16,7 +19,7 @@ public class FloatType(llvmType: LLVMTypeRef) : Type(llvmType) {
      *
      * This function will create a fp type of the provided [kind].
      */
-    public constructor(kind: TypeKind, ctx: Context = Context.getGlobalContext()) {
+    public constructor(kind: TypeKind, ctx: Context = Context.getGlobalContext()) : this() {
         ref = when (kind) {
             TypeKind.Half -> LLVM.LLVMHalfTypeInContext(ctx.ref)
             TypeKind.Float -> LLVM.LLVMFloatTypeInContext(ctx.ref)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FloatType.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.core.types
 
+import dev.supergrecko.kllvm.contracts.Unreachable
 import dev.supergrecko.kllvm.core.enumerations.TypeKind
 import dev.supergrecko.kllvm.core.typedefs.Context
 import dev.supergrecko.kllvm.core.typedefs.Type
@@ -8,33 +9,28 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class FloatType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    //region Core::Values::Constants::ScalarConstants
-    public fun getConstantFloat(value: Double): FloatValue {
-        return FloatValue(LLVM.LLVMConstReal(llvmType, value))
-    }
-    //endregion Core::Values::Constants::ScalarConstants
+    public constructor(type: Type) : this(type.ref)
 
-    public companion object {
-        /**
-         * Create a floating point type
-         *
-         * This function will create a fp type of the provided [kind].
-         */
-        @JvmStatic
-        public fun new(kind: TypeKind, ctx: Context = Context.getGlobalContext()): FloatType {
-            val type = when (kind) {
-                TypeKind.Half -> LLVM.LLVMHalfTypeInContext(ctx.ref)
-                TypeKind.Float -> LLVM.LLVMFloatTypeInContext(ctx.ref)
-                TypeKind.Double -> LLVM.LLVMDoubleTypeInContext(ctx.ref)
-                TypeKind.X86_FP80 -> LLVM.LLVMX86FP80TypeInContext(ctx.ref)
-                TypeKind.FP128 -> LLVM.LLVMFP128TypeInContext(ctx.ref)
-                TypeKind.PPC_FP128 -> LLVM.LLVMPPCFP128TypeInContext(ctx.ref)
-                else -> {
-                    throw IllegalArgumentException("Type kind '$kind' is not a floating point type")
-                }
-            }
-
-            return FloatType(type)
+    /**
+     * Create a floating point type
+     *
+     * This function will create a fp type of the provided [kind].
+     */
+    public constructor(kind: TypeKind, ctx: Context = Context.getGlobalContext()) {
+        ref = when (kind) {
+            TypeKind.Half -> LLVM.LLVMHalfTypeInContext(ctx.ref)
+            TypeKind.Float -> LLVM.LLVMFloatTypeInContext(ctx.ref)
+            TypeKind.Double -> LLVM.LLVMDoubleTypeInContext(ctx.ref)
+            TypeKind.X86_FP80 -> LLVM.LLVMX86FP80TypeInContext(ctx.ref)
+            TypeKind.FP128 -> LLVM.LLVMFP128TypeInContext(ctx.ref)
+            TypeKind.PPC_FP128 -> LLVM.LLVMPPCFP128TypeInContext(ctx.ref)
+            else -> throw Unreachable()
         }
     }
+
+    //region Core::Values::Constants::ScalarConstants
+    public fun getConstantFloat(value: Double): FloatValue {
+        return FloatValue(LLVM.LLVMConstReal(ref, value))
+    }
+    //endregion Core::Values::Constants::ScalarConstants
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/FunctionType.kt
@@ -8,7 +8,11 @@ import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class FunctionType(llvmType: LLVMTypeRef) : Type(llvmType) {
+public class FunctionType internal constructor() : Type() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
     public constructor(type: Type) : this(type.ref)
 
     /**
@@ -18,7 +22,7 @@ public class FunctionType(llvmType: LLVMTypeRef) : Type(llvmType) {
      * parameters of the types provided in [tys]. You can mark a function type as variadic by setting the [variadic] arg
      * to true.
      */
-    public constructor(returns: Type, types: List<Type>, variadic: Boolean) {
+    public constructor(returns: Type, types: List<Type>, variadic: Boolean) : this() {
         val arr = ArrayList(types.map { it.ref }).toTypedArray()
 
         ref = LLVM.LLVMFunctionType(returns.ref, PointerPointer(*arr), arr.size, variadic.toInt())

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
@@ -8,52 +8,49 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class IntType(llvmType: LLVMTypeRef) : Type(llvmType) {
+    public constructor(type: Type) : this(type.ref)
+
+    /**
+     * Create an integer type
+     *
+     * This will create an integer type of the size [size]. If the size matches any of LLVM's preset integer sizes then
+     * that size will be returned. Otherwise an arbitrary size int type will be returned ([LLVM.LLVMIntTypeInContext]).
+     */
+    public constructor(size: Int, ctx: Context = Context.getGlobalContext()) {
+        ref = when (size) {
+            1 -> LLVM.LLVMInt1TypeInContext(ctx.ref)
+            8 -> LLVM.LLVMInt8TypeInContext(ctx.ref)
+            16 -> LLVM.LLVMInt16TypeInContext(ctx.ref)
+            32 -> LLVM.LLVMInt32TypeInContext(ctx.ref)
+            64 -> LLVM.LLVMInt64TypeInContext(ctx.ref)
+            128 -> LLVM.LLVMInt128TypeInContext(ctx.ref)
+            else -> {
+                require(size in 1..8388606) { "LLVM only supports integers of 2^23-1 bits size" }
+
+                LLVM.LLVMIntTypeInContext(ctx.ref, size)
+            }
+        }
+    }
+
     //region Core::Types::Int
     public fun getTypeWidth(): Int {
-        return LLVM.LLVMGetIntTypeWidth(llvmType)
+        return LLVM.LLVMGetIntTypeWidth(ref)
     }
     //endregion Core::Types::Int
 
     //region Core::Values::Constants
     public fun getConstantAllOnes(): IntValue {
-        return IntValue(LLVM.LLVMConstAllOnes(llvmType))
+        return IntValue(LLVM.LLVMConstAllOnes(ref))
     }
     //endregion Core::Values::Constants
 
     //region Core::Values::Constants::ScalarConstants
     public fun getConstantInt(value: Long, signExtend: Boolean): IntValue {
-        return IntValue(LLVM.LLVMConstInt(llvmType, value, signExtend.toInt()))
+        return IntValue(LLVM.LLVMConstInt(ref, value, signExtend.toInt()))
     }
 
     public fun getConstantIntAP(words: List<Long>): IntValue {
-        return IntValue(LLVM.LLVMConstIntOfArbitraryPrecision(llvmType, words.size, words.toLongArray()))
+        return IntValue(LLVM.LLVMConstIntOfArbitraryPrecision(ref, words.size, words.toLongArray()))
     }
     //endregion Core::Values::Constants::ScalarConstants
-
-    public companion object {
-        /**
-         * Create an integer type
-         *
-         * This will create an integer type of the size [size]. If the size matches any of LLVM's preset integer sizes then
-         * that size will be returned. Otherwise an arbitrary size int type will be returned ([LLVM.LLVMIntTypeInContext]).
-         */
-        @JvmStatic
-        public fun new(size: Int, ctx: Context = Context.getGlobalContext()): IntType {
-            val type = when (size) {
-                1 -> LLVM.LLVMInt1TypeInContext(ctx.ref)
-                8 -> LLVM.LLVMInt8TypeInContext(ctx.ref)
-                16 -> LLVM.LLVMInt16TypeInContext(ctx.ref)
-                32 -> LLVM.LLVMInt32TypeInContext(ctx.ref)
-                64 -> LLVM.LLVMInt64TypeInContext(ctx.ref)
-                128 -> LLVM.LLVMInt128TypeInContext(ctx.ref)
-                else -> {
-                    require(size in 1..8388606) { "LLVM only supports integers of 2^23-1 bits size" }
-
-                    LLVM.LLVMIntTypeInContext(ctx.ref, size)
-                }
-            }
-
-            return IntType(type)
-        }
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
@@ -2,7 +2,6 @@ package dev.supergrecko.kllvm.core.types
 
 import dev.supergrecko.kllvm.core.typedefs.Context
 import dev.supergrecko.kllvm.core.typedefs.Type
-import dev.supergrecko.kllvm.core.typedefs.Value
 import dev.supergrecko.kllvm.core.values.IntValue
 import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
@@ -41,16 +40,16 @@ public class IntType(llvmType: LLVMTypeRef) : Type(llvmType) {
         @JvmStatic
         public fun new(size: Int, ctx: Context = Context.getGlobalContext()): IntType {
             val type = when (size) {
-                1 -> LLVM.LLVMInt1TypeInContext(ctx.llvmCtx)
-                8 -> LLVM.LLVMInt8TypeInContext(ctx.llvmCtx)
-                16 -> LLVM.LLVMInt16TypeInContext(ctx.llvmCtx)
-                32 -> LLVM.LLVMInt32TypeInContext(ctx.llvmCtx)
-                64 -> LLVM.LLVMInt64TypeInContext(ctx.llvmCtx)
-                128 -> LLVM.LLVMInt128TypeInContext(ctx.llvmCtx)
+                1 -> LLVM.LLVMInt1TypeInContext(ctx.ref)
+                8 -> LLVM.LLVMInt8TypeInContext(ctx.ref)
+                16 -> LLVM.LLVMInt16TypeInContext(ctx.ref)
+                32 -> LLVM.LLVMInt32TypeInContext(ctx.ref)
+                64 -> LLVM.LLVMInt64TypeInContext(ctx.ref)
+                128 -> LLVM.LLVMInt128TypeInContext(ctx.ref)
                 else -> {
                     require(size in 1..8388606) { "LLVM only supports integers of 2^23-1 bits size" }
 
-                    LLVM.LLVMIntTypeInContext(ctx.llvmCtx, size)
+                    LLVM.LLVMIntTypeInContext(ctx.ref, size)
                 }
             }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
@@ -43,14 +43,4 @@ public class IntType(llvmType: LLVMTypeRef) : Type(llvmType) {
         return IntValue(LLVM.LLVMConstAllOnes(ref))
     }
     //endregion Core::Values::Constants
-
-    //region Core::Values::Constants::ScalarConstants
-    public fun getConstantInt(value: Long, signExtend: Boolean): IntValue {
-        return IntValue(LLVM.LLVMConstInt(ref, value, signExtend.toInt()))
-    }
-
-    public fun getConstantIntAP(words: List<Long>): IntValue {
-        return IntValue(LLVM.LLVMConstIntOfArbitraryPrecision(ref, words.size, words.toLongArray()))
-    }
-    //endregion Core::Values::Constants::ScalarConstants
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/IntType.kt
@@ -3,11 +3,14 @@ package dev.supergrecko.kllvm.core.types
 import dev.supergrecko.kllvm.core.typedefs.Context
 import dev.supergrecko.kllvm.core.typedefs.Type
 import dev.supergrecko.kllvm.core.values.IntValue
-import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class IntType(llvmType: LLVMTypeRef) : Type(llvmType) {
+public class IntType internal constructor() : Type() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
     public constructor(type: Type) : this(type.ref)
 
     /**
@@ -16,7 +19,7 @@ public class IntType(llvmType: LLVMTypeRef) : Type(llvmType) {
      * This will create an integer type of the size [size]. If the size matches any of LLVM's preset integer sizes then
      * that size will be returned. Otherwise an arbitrary size int type will be returned ([LLVM.LLVMIntTypeInContext]).
      */
-    public constructor(size: Int, ctx: Context = Context.getGlobalContext()) {
+    public constructor(size: Int, ctx: Context = Context.getGlobalContext()) : this() {
         ref = when (size) {
             1 -> LLVM.LLVMInt1TypeInContext(ctx.ref)
             8 -> LLVM.LLVMInt8TypeInContext(ctx.ref)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LabelType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LabelType.kt
@@ -9,7 +9,7 @@ public class LabelType(llvmType: LLVMTypeRef) : Type(llvmType) {
     public companion object {
         @JvmStatic
         public fun new(ctx: Context = Context.getGlobalContext()): LabelType {
-            val ty = LLVM.LLVMLabelTypeInContext(ctx.llvmCtx)
+            val ty = LLVM.LLVMLabelTypeInContext(ctx.ref)
 
             return LabelType(ty)
         }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LabelType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LabelType.kt
@@ -6,12 +6,9 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class LabelType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public companion object {
-        @JvmStatic
-        public fun new(ctx: Context = Context.getGlobalContext()): LabelType {
-            val ty = LLVM.LLVMLabelTypeInContext(ctx.ref)
+    public constructor(type: Type) : this(type.ref)
 
-            return LabelType(ty)
-        }
+    public constructor(context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMLabelTypeInContext(context.ref)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/LabelType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/LabelType.kt
@@ -5,10 +5,15 @@ import dev.supergrecko.kllvm.core.typedefs.Type
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class LabelType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public constructor(type: Type) : this(type.ref)
-
-    public constructor(context: Context = Context.getGlobalContext()) {
+public class LabelType public constructor(context: Context = Context.getGlobalContext()) : Type() {
+    init {
         ref = LLVM.LLVMLabelTypeInContext(context.ref)
+
     }
+
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
+    public constructor(type: Type) : this(type.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/MetadataType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/MetadataType.kt
@@ -5,10 +5,14 @@ import dev.supergrecko.kllvm.core.typedefs.Type
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class MetadataType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public constructor(type: Type) : this(type.ref)
-
-    public constructor(context: Context = Context.getGlobalContext()) {
+public class MetadataType public constructor(context: Context = Context.getGlobalContext()) : Type() {
+    init {
         ref = LLVM.LLVMMetadataTypeInContext(context.ref)
     }
+
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
+    public constructor(type: Type) : this(type.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/MetadataType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/MetadataType.kt
@@ -6,12 +6,9 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class MetadataType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public companion object {
-        @JvmStatic
-        public fun new(ctx: Context = Context.getGlobalContext()): MetadataType {
-            val ty = LLVM.LLVMMetadataTypeInContext(ctx.ref)
+    public constructor(type: Type) : this(type.ref)
 
-            return MetadataType(ty)
-        }
+    public constructor(context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMMetadataTypeInContext(context.ref)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/MetadataType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/MetadataType.kt
@@ -9,7 +9,7 @@ public class MetadataType(llvmType: LLVMTypeRef) : Type(llvmType) {
     public companion object {
         @JvmStatic
         public fun new(ctx: Context = Context.getGlobalContext()): MetadataType {
-            val ty = LLVM.LLVMMetadataTypeInContext(ctx.llvmCtx)
+            val ty = LLVM.LLVMMetadataTypeInContext(ctx.ref)
 
             return MetadataType(ty)
         }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/PointerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/PointerType.kt
@@ -7,7 +7,11 @@ import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class PointerType(llvmType: LLVMTypeRef) : Type(llvmType) {
+public class PointerType internal constructor() : Type() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
     public constructor(type: Type) : this(type.ref)
 
     /**
@@ -15,7 +19,7 @@ public class PointerType(llvmType: LLVMTypeRef) : Type(llvmType) {
      *
      * Creates a pointer type of type [ty]. An address space may be provided, but defaults to 0.
      */
-    public constructor(type: Type, address: Int = 0) {
+    public constructor(type: Type, address: Int = 0) : this() {
         require(address >= 0) { "Cannot use negative address" }
 
         ref = LLVM.LLVMPointerType(type.ref, address)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/PointerType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/PointerType.kt
@@ -8,9 +8,22 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class PointerType(llvmType: LLVMTypeRef) : Type(llvmType) {
+    public constructor(type: Type) : this(type.ref)
+
+    /**
+     * Create a pointer type
+     *
+     * Creates a pointer type of type [ty]. An address space may be provided, but defaults to 0.
+     */
+    public constructor(type: Type, address: Int = 0) {
+        require(address >= 0) { "Cannot use negative address" }
+
+        ref = LLVM.LLVMPointerType(type.ref, address)
+    }
+
     //region Core::Types::SequentialTypes
     public fun getAddressSpace(): Int {
-        return LLVM.LLVMGetPointerAddressSpace(llvmType)
+        return LLVM.LLVMGetPointerAddressSpace(ref)
     }
 
     /**
@@ -20,7 +33,7 @@ public class PointerType(llvmType: LLVMTypeRef) : Type(llvmType) {
      */
     @Shared
     public fun getElementCount(): Int {
-        return LLVM.LLVMGetNumContainedTypes(llvmType)
+        return LLVM.LLVMGetNumContainedTypes(ref)
     }
 
     /**
@@ -31,7 +44,7 @@ public class PointerType(llvmType: LLVMTypeRef) : Type(llvmType) {
     @Shared
     public fun getSubtypes(): List<Type> {
         val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
-        LLVM.LLVMGetSubtypes(llvmType, dest)
+        LLVM.LLVMGetSubtypes(ref, dest)
 
         return dest.iterateIntoType { Type(it) }
     }
@@ -43,25 +56,9 @@ public class PointerType(llvmType: LLVMTypeRef) : Type(llvmType) {
      */
     @Shared
     public fun getElementType(): Type {
-        val type = LLVM.LLVMGetElementType(llvmType)
+        val type = LLVM.LLVMGetElementType(ref)
 
         return Type(type)
     }
     //endregion Core::Types::SequentialTypes
-
-    public companion object {
-        /**
-         * Create a pointer type
-         *
-         * Creates a pointer type of type [ty]. An address space may be provided, but defaults to 0.
-         */
-        @JvmStatic
-        public fun new(ty: Type, address: Int = 0): PointerType {
-            require(address >= 0) { "Cannot use negative address" }
-
-            val ptr = LLVM.LLVMPointerType(ty.llvmType, address)
-
-            return PointerType(ptr)
-        }
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
@@ -69,9 +69,9 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
      * Create an anonymous ConstantStruct with the specified [values]
      */
     public fun getConstStruct(values: List<Value>, packed: Boolean, context: Context = Context.getGlobalContext()): StructValue {
-        val ptr = ArrayList(values.map { it.llvmValue }).toTypedArray()
+        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
 
-        val struct = LLVM.LLVMConstStructInContext(context.llvmCtx, PointerPointer(*ptr), ptr.size, packed.toInt())
+        val struct = LLVM.LLVMConstStructInContext(context.ref, PointerPointer(*ptr), ptr.size, packed.toInt())
 
         return StructValue(struct)
     }
@@ -80,7 +80,7 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
      * Create a non-anonymous ConstantStruct from values.
      */
     public fun getConstNamedStruct(type: StructType, values: List<Value>): StructValue {
-        val ptr = ArrayList(values.map { it.llvmValue }).toTypedArray()
+        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
 
         val struct = LLVM.LLVMConstNamedStruct(type.llvmType, PointerPointer(*ptr), ptr.size)
 
@@ -101,7 +101,7 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
         public fun new(types: List<Type>, packed: Boolean, ctx: Context = Context.getGlobalContext()): StructType {
             val arr = ArrayList(types.map { it.llvmType }).toTypedArray()
 
-            val struct = LLVM.LLVMStructTypeInContext(ctx.llvmCtx, PointerPointer(*arr), arr.size, packed.toInt())
+            val struct = LLVM.LLVMStructTypeInContext(ctx.ref, PointerPointer(*arr), arr.size, packed.toInt())
 
             return StructType(struct)
         }
@@ -114,7 +114,7 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
          */
         @JvmStatic
         public fun opaque(name: String, ctx: Context = Context.getGlobalContext()): StructType {
-            val struct = LLVM.LLVMStructCreateNamed(ctx.llvmCtx, name)
+            val struct = LLVM.LLVMStructCreateNamed(ctx.ref, name)
 
             return StructType(struct)
         }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
@@ -89,28 +89,4 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
         return LLVM.LLVMCountStructElementTypes(ref)
     }
     //endregion Core::Types::StructureTypes
-
-    //region Core::Values::Constants::CompositeConstants
-    /**
-     * Create an anonymous ConstantStruct with the specified [values]
-     */
-    public fun getConstStruct(values: List<Value>, packed: Boolean, context: Context = Context.getGlobalContext()): StructValue {
-        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
-
-        val struct = LLVM.LLVMConstStructInContext(context.ref, PointerPointer(*ptr), ptr.size, packed.toInt())
-
-        return StructValue(struct)
-    }
-
-    /**
-     * Create a non-anonymous ConstantStruct from values.
-     */
-    public fun getConstNamedStruct(type: StructType, values: List<Value>): StructValue {
-        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
-
-        val struct = LLVM.LLVMConstNamedStruct(type.ref, PointerPointer(*ptr), ptr.size)
-
-        return StructValue(struct)
-    }
-    //endregion Core::Values::Constants::CompositeConstants
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
@@ -12,34 +12,60 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
+    public constructor(type: Type) : this(type.ref)
+
+    /**
+     * Create a structure type
+     *
+     * This method creates a structure type inside the given [ctx]. Do not that this method cannot produce opaque struct
+     * types, use [opaque] for that.
+     *
+     * The struct body will be the types provided in [tys].
+     */
+    public constructor(types: List<Type>, packed: Boolean, ctx: Context = Context.getGlobalContext()) {
+        val arr = ArrayList(types.map { it.ref }).toTypedArray()
+
+        ref = LLVM.LLVMStructTypeInContext(ctx.ref, PointerPointer(*arr), arr.size, packed.toInt())
+    }
+
+    /**
+     * Create an opaque struct type
+     *
+     * This will create an opaque struct (a struct without a body, like C forward declaration) with the given [name].
+     * You will be able to use [setBody] to assign a body to the opaque struct.
+     */
+    public constructor(name: String, ctx: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMStructCreateNamed(ctx.ref, name)
+    }
+
     //region Core::Types::StructureTypes
     public fun isPacked(): Boolean {
-        return LLVM.LLVMIsPackedStruct(llvmType).toBoolean()
+        return LLVM.LLVMIsPackedStruct(ref).toBoolean()
     }
 
     public fun isOpaque(): Boolean {
-        return LLVM.LLVMIsOpaqueStruct(llvmType).toBoolean()
+        return LLVM.LLVMIsOpaqueStruct(ref).toBoolean()
     }
 
     public fun isLiteral(): Boolean {
-        return LLVM.LLVMIsLiteralStruct(llvmType).toBoolean()
+        return LLVM.LLVMIsLiteralStruct(ref).toBoolean()
     }
 
     public fun setBody(elementTypes: List<Type>, packed: Boolean) {
         require(isOpaque())
 
-        val types = elementTypes.map { it.llvmType }
+        val types = elementTypes.map { it.ref }
         val array = ArrayList(types).toTypedArray()
         val ptr = PointerPointer(*array)
 
-        LLVM.LLVMStructSetBody(llvmType, ptr, array.size, packed.toInt())
+        LLVM.LLVMStructSetBody(ref, ptr, array.size, packed.toInt())
     }
 
     public fun getElementTypeAt(index: Int): Type {
         // Refactor when moved
         require(index <= getElementCount()) { "Requested index $index is out of bounds for this struct" }
 
-        val type = LLVM.LLVMStructGetTypeAtIndex(llvmType, index)
+        val type = LLVM.LLVMStructGetTypeAtIndex(ref, index)
 
         return Type(type)
     }
@@ -47,20 +73,20 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
     public fun getName(): String {
         require(!isLiteral()) { "Literal structs are never named" }
 
-        val name = LLVM.LLVMGetStructName(llvmType)
+        val name = LLVM.LLVMGetStructName(ref)
 
         return name.string
     }
 
     public fun getElementTypes(): List<Type> {
         val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
-        LLVM.LLVMGetStructElementTypes(llvmType, dest)
+        LLVM.LLVMGetStructElementTypes(ref, dest)
 
         return dest.iterateIntoType { Type(it) }
     }
 
     public fun getElementCount(): Int {
-        return LLVM.LLVMCountStructElementTypes(llvmType)
+        return LLVM.LLVMCountStructElementTypes(ref)
     }
     //endregion Core::Types::StructureTypes
 
@@ -82,41 +108,9 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
     public fun getConstNamedStruct(type: StructType, values: List<Value>): StructValue {
         val ptr = ArrayList(values.map { it.ref }).toTypedArray()
 
-        val struct = LLVM.LLVMConstNamedStruct(type.llvmType, PointerPointer(*ptr), ptr.size)
+        val struct = LLVM.LLVMConstNamedStruct(type.ref, PointerPointer(*ptr), ptr.size)
 
         return StructValue(struct)
     }
     //endregion Core::Values::Constants::CompositeConstants
-
-    public companion object {
-        /**
-         * Create a structure type
-         *
-         * This method creates a structure type inside the given [ctx]. Do not that this method cannot produce opaque struct
-         * types, use [opaque] for that.
-         *
-         * The struct body will be the types provided in [tys].
-         */
-        @JvmStatic
-        public fun new(types: List<Type>, packed: Boolean, ctx: Context = Context.getGlobalContext()): StructType {
-            val arr = ArrayList(types.map { it.llvmType }).toTypedArray()
-
-            val struct = LLVM.LLVMStructTypeInContext(ctx.ref, PointerPointer(*arr), arr.size, packed.toInt())
-
-            return StructType(struct)
-        }
-
-        /**
-         * Create an opaque struct type
-         *
-         * This will create an opaque struct (a struct without a body, like C forward declaration) with the given [name].
-         * You will be able to use [setBody] to assign a body to the opaque struct.
-         */
-        @JvmStatic
-        public fun opaque(name: String, ctx: Context = Context.getGlobalContext()): StructType {
-            val struct = LLVM.LLVMStructCreateNamed(ctx.ref, name)
-
-            return StructType(struct)
-        }
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/StructType.kt
@@ -2,8 +2,6 @@ package dev.supergrecko.kllvm.core.types
 
 import dev.supergrecko.kllvm.core.typedefs.Context
 import dev.supergrecko.kllvm.core.typedefs.Type
-import dev.supergrecko.kllvm.core.typedefs.Value
-import dev.supergrecko.kllvm.core.values.StructValue
 import dev.supergrecko.kllvm.utils.iterateIntoType
 import dev.supergrecko.kllvm.utils.toBoolean
 import dev.supergrecko.kllvm.utils.toInt
@@ -11,7 +9,11 @@ import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
+public class StructType internal constructor() : Type() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
     public constructor(type: Type) : this(type.ref)
 
     /**
@@ -22,7 +24,7 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
      *
      * The struct body will be the types provided in [tys].
      */
-    public constructor(types: List<Type>, packed: Boolean, ctx: Context = Context.getGlobalContext()) {
+    public constructor(types: List<Type>, packed: Boolean, ctx: Context = Context.getGlobalContext()) : this() {
         val arr = ArrayList(types.map { it.ref }).toTypedArray()
 
         ref = LLVM.LLVMStructTypeInContext(ctx.ref, PointerPointer(*arr), arr.size, packed.toInt())
@@ -34,7 +36,7 @@ public class StructType(llvmType: LLVMTypeRef) : Type(llvmType) {
      * This will create an opaque struct (a struct without a body, like C forward declaration) with the given [name].
      * You will be able to use [setBody] to assign a body to the opaque struct.
      */
-    public constructor(name: String, ctx: Context = Context.getGlobalContext()) {
+    public constructor(name: String, ctx: Context = Context.getGlobalContext()) : this() {
         ref = LLVM.LLVMStructCreateNamed(ctx.ref, name)
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
@@ -5,9 +5,12 @@ import dev.supergrecko.kllvm.core.typedefs.Type
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class TokenType(llvmType: LLVMTypeRef) : Type(llvmType) {
-
-    public constructor(context: Context = Context.getGlobalContext()) {
+public class TokenType public constructor(context: Context = Context.getGlobalContext()) : Type() {
+    init {
         ref = LLVM.LLVMTokenTypeInContext(context.ref)
+    }
+
+    internal constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
@@ -10,7 +10,7 @@ public class TokenType public constructor(context: Context = Context.getGlobalCo
         ref = LLVM.LLVMTokenTypeInContext(context.ref)
     }
 
-    internal constructor(llvmType: LLVMTypeRef) : this() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
         ref = llvmType
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
@@ -9,7 +9,7 @@ public class TokenType(llvmType: LLVMTypeRef) : Type(llvmType) {
     public companion object {
         @JvmStatic
         public fun new(ctx: Context = Context.getGlobalContext()): TokenType {
-            val ty = LLVM.LLVMTokenTypeInContext(ctx.llvmCtx)
+            val ty = LLVM.LLVMTokenTypeInContext(ctx.ref)
 
             return TokenType(ty)
         }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/TokenType.kt
@@ -6,12 +6,8 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class TokenType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public companion object {
-        @JvmStatic
-        public fun new(ctx: Context = Context.getGlobalContext()): TokenType {
-            val ty = LLVM.LLVMTokenTypeInContext(ctx.ref)
 
-            return TokenType(ty)
-        }
+    public constructor(context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMTokenTypeInContext(context.ref)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
@@ -2,14 +2,16 @@ package dev.supergrecko.kllvm.core.types
 
 import dev.supergrecko.kllvm.annotations.Shared
 import dev.supergrecko.kllvm.core.typedefs.Type
-import dev.supergrecko.kllvm.core.typedefs.Value
-import dev.supergrecko.kllvm.core.values.VectorValue
 import dev.supergrecko.kllvm.utils.iterateIntoType
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
+public class VectorType internal constructor() : Type() {
+    internal constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
     public constructor(type: Type) : this(type.ref)
 
     /**
@@ -17,7 +19,7 @@ public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
      *
      * Constructs a vector type of type [ty] with size [size].
      */
-    public constructor(type: Type, size: Int) {
+    public constructor(type: Type, size: Int) : this() {
         require(size >= 0) { "Cannot make vector of negative size" }
 
         ref = LLVM.LLVMVectorType(type.ref, size)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
@@ -10,6 +10,19 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
+    public constructor(type: Type) : this(type.ref)
+
+    /**
+     * Create a vector type
+     *
+     * Constructs a vector type of type [ty] with size [size].
+     */
+    public constructor(type: Type, size: Int) {
+        require(size >= 0) { "Cannot make vector of negative size" }
+
+        ref = LLVM.LLVMVectorType(type.ref, size)
+    }
+
     //region Core::Types::SequentialTypes
     /**
      * Returns the amount of elements contained in this type
@@ -18,7 +31,7 @@ public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
      */
     @Shared
     public fun getElementCount(): Int {
-        return LLVM.LLVMGetVectorSize(llvmType)
+        return LLVM.LLVMGetVectorSize(ref)
     }
 
     /**
@@ -29,7 +42,7 @@ public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
     @Shared
     public fun getSubtypes(): List<Type> {
         val dest = PointerPointer<LLVMTypeRef>(getElementCount().toLong())
-        LLVM.LLVMGetSubtypes(llvmType, dest)
+        LLVM.LLVMGetSubtypes(ref, dest)
 
         return dest.iterateIntoType { Type(it) }
     }
@@ -41,7 +54,7 @@ public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
      */
     @Shared
     public fun getElementType(): Type {
-        val type = LLVM.LLVMGetElementType(llvmType)
+        val type = LLVM.LLVMGetElementType(ref)
 
         return Type(type)
     }
@@ -56,18 +69,4 @@ public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
         return VectorValue(vec)
     }
     //endregion Core::Values::Constants::CompositeConstants
-
-    public companion object {
-        /**
-         * Create a vector type
-         *
-         * Constructs a vector type of type [ty] with size [size].
-         */
-        @JvmStatic
-        public fun new(type: Type, size: Int): VectorType {
-            require(size >= 0) { "Cannot make vector of negative size" }
-
-            return VectorType(LLVM.LLVMVectorType(type.llvmType, size))
-        }
-    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
@@ -59,14 +59,4 @@ public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
         return Type(type)
     }
     //endregion Core::Types::SequentialTypes
-
-    //region Core::Values::Constants::CompositeConstants
-    public fun getConstantVector(values: List<Value>): VectorValue {
-        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
-
-        val vec = LLVM.LLVMConstVector(PointerPointer(*ptr), ptr.size)
-
-        return VectorValue(vec)
-    }
-    //endregion Core::Values::Constants::CompositeConstants
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
@@ -49,7 +49,7 @@ public class VectorType(llvmType: LLVMTypeRef) : Type(llvmType) {
 
     //region Core::Values::Constants::CompositeConstants
     public fun getConstantVector(values: List<Value>): VectorValue {
-        val ptr = ArrayList(values.map { it.llvmValue }).toTypedArray()
+        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
 
         val vec = LLVM.LLVMConstVector(PointerPointer(*ptr), ptr.size)
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VectorType.kt
@@ -8,7 +8,7 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class VectorType internal constructor() : Type() {
-    internal constructor(llvmType: LLVMTypeRef) : this() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
         ref = llvmType
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
@@ -10,7 +10,7 @@ public class VoidType public constructor(context: Context = Context.getGlobalCon
         ref = LLVM.LLVMVoidTypeInContext(context.ref)
     }
 
-    internal constructor(llvmType: LLVMTypeRef) : this() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
         ref = llvmType
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
@@ -9,7 +9,7 @@ public class VoidType(llvmType: LLVMTypeRef) : Type(llvmType) {
     public companion object {
         @JvmStatic
         public fun new(ctx: Context = Context.getGlobalContext()): VoidType {
-            return VoidType(LLVM.LLVMVoidTypeInContext(ctx.llvmCtx))
+            return VoidType(LLVM.LLVMVoidTypeInContext(ctx.ref))
         }
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
@@ -5,10 +5,14 @@ import dev.supergrecko.kllvm.core.typedefs.Type
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class VoidType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public constructor(type: Type) : this(type.ref)
-
-    public constructor(context: Context = Context.getGlobalContext()) {
+public class VoidType public constructor(context: Context = Context.getGlobalContext()) : Type() {
+    init {
         ref = LLVM.LLVMVoidTypeInContext(context.ref)
     }
+
+    internal constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
+    public constructor(type: Type) : this(type.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/VoidType.kt
@@ -6,10 +6,9 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class VoidType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public companion object {
-        @JvmStatic
-        public fun new(ctx: Context = Context.getGlobalContext()): VoidType {
-            return VoidType(LLVM.LLVMVoidTypeInContext(ctx.ref))
-        }
+    public constructor(type: Type) : this(type.ref)
+
+    public constructor(context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMVoidTypeInContext(context.ref)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
@@ -6,12 +6,9 @@ import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class X86MMXType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public companion object {
-        @JvmStatic
-        public fun new(ctx: Context = Context.getGlobalContext()): X86MMXType {
-            val ty = LLVM.LLVMX86MMXTypeInContext(ctx.ref)
+    public constructor(type: Type) : this(type.ref)
 
-            return X86MMXType(ty)
-        }
+    public constructor(context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMX86MMXTypeInContext(context.ref)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
@@ -5,10 +5,14 @@ import dev.supergrecko.kllvm.core.typedefs.Type
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class X86MMXType(llvmType: LLVMTypeRef) : Type(llvmType) {
-    public constructor(type: Type) : this(type.ref)
-
-    public constructor(context: Context = Context.getGlobalContext()) {
+public class X86MMXType public constructor(context: Context = Context.getGlobalContext()) : Type() {
+    init {
         ref = LLVM.LLVMX86MMXTypeInContext(context.ref)
     }
+
+    internal constructor(llvmType: LLVMTypeRef) : this() {
+        ref = llvmType
+    }
+
+    public constructor(type: Type) : this(type.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
@@ -9,7 +9,7 @@ public class X86MMXType(llvmType: LLVMTypeRef) : Type(llvmType) {
     public companion object {
         @JvmStatic
         public fun new(ctx: Context = Context.getGlobalContext()): X86MMXType {
-            val ty = LLVM.LLVMX86MMXTypeInContext(ctx.llvmCtx)
+            val ty = LLVM.LLVMX86MMXTypeInContext(ctx.ref)
 
             return X86MMXType(ty)
         }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/types/X86MMXType.kt
@@ -10,7 +10,7 @@ public class X86MMXType public constructor(context: Context = Context.getGlobalC
         ref = LLVM.LLVMX86MMXTypeInContext(context.ref)
     }
 
-    internal constructor(llvmType: LLVMTypeRef) : this() {
+    public constructor(llvmType: LLVMTypeRef) : this() {
         ref = llvmType
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
@@ -10,13 +10,13 @@ import org.bytedeco.llvm.global.LLVM
 public class ArrayValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
     //region Core::Values::Constants::CompositeConstants
     public fun isConstantString(): Boolean {
-        return LLVM.LLVMIsConstantString(llvmValue).toBoolean()
+        return LLVM.LLVMIsConstantString(ref).toBoolean()
     }
 
     public fun getAsString(): String {
         require(isConstantString())
 
-        val ptr = LLVM.LLVMGetAsString(llvmValue, SizeTPointer(0))
+        val ptr = LLVM.LLVMGetAsString(ref, SizeTPointer(0))
 
         return ptr.string
     }
@@ -28,7 +28,7 @@ public class ArrayValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
      */
     @Shared
     public fun getElementAsConstant(index: Int): Value {
-        val value = LLVM.LLVMGetElementAsConstant(llvmValue, index)
+        val value = LLVM.LLVMGetElementAsConstant(ref, index)
 
         return Value(value)
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
@@ -2,7 +2,6 @@ package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.annotations.Shared
 import dev.supergrecko.kllvm.core.typedefs.Context
-import dev.supergrecko.kllvm.core.typedefs.Type
 import dev.supergrecko.kllvm.core.typedefs.Value
 import dev.supergrecko.kllvm.utils.toBoolean
 import dev.supergrecko.kllvm.utils.toInt
@@ -10,10 +9,14 @@ import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ArrayValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class ArrayValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 
-    public constructor(content: String, nullTerminate: Boolean, context: Context = Context.getGlobalContext()) {
+    public constructor(content: String, nullTerminate: Boolean, context: Context = Context.getGlobalContext()) : this() {
         ref = LLVM.LLVMConstStringInContext(context.ref, content, content.length, nullTerminate.toInt())
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
@@ -1,13 +1,22 @@
 package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.annotations.Shared
+import dev.supergrecko.kllvm.core.typedefs.Context
+import dev.supergrecko.kllvm.core.typedefs.Type
 import dev.supergrecko.kllvm.core.typedefs.Value
 import dev.supergrecko.kllvm.utils.toBoolean
+import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class ArrayValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+
+    public constructor(content: String, nullTerminate: Boolean, context: Context = Context.getGlobalContext()) {
+        ref = LLVM.LLVMConstStringInContext(context.ref, content, content.length, nullTerminate.toInt())
+    }
+
     //region Core::Values::Constants::CompositeConstants
     public fun isConstantString(): Boolean {
         return LLVM.LLVMIsConstantString(ref).toBoolean()

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/ArrayValue.kt
@@ -10,7 +10,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class ArrayValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/BasicValueUse.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/BasicValueUse.kt
@@ -5,7 +5,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 // TODO: Learn how to use/implement this
 public class BasicValueUse internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/BasicValueUse.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/BasicValueUse.kt
@@ -4,4 +4,6 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 // TODO: Learn how to use/implement this
-public class BasicValueUse(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class BasicValueUse(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/BasicValueUse.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/BasicValueUse.kt
@@ -4,6 +4,10 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 // TODO: Learn how to use/implement this
-public class BasicValueUse(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class BasicValueUse internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/CallSiteValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/CallSiteValue.kt
@@ -3,6 +3,10 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class CallSiteValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class CallSiteValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/CallSiteValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/CallSiteValue.kt
@@ -3,4 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class CallSiteValue(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class CallSiteValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/CallSiteValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/CallSiteValue.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 public class CallSiteValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
@@ -8,7 +8,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class FloatValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
@@ -7,10 +7,14 @@ import org.bytedeco.javacpp.IntPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class FloatValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class FloatValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 
-    public constructor(type: FloatType, value: Double) {
+    public constructor(type: FloatType, value: Double) : this() {
         ref = LLVM.LLVMConstReal(type.ref, value)
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
@@ -1,12 +1,19 @@
 package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.core.typedefs.Value
+import dev.supergrecko.kllvm.core.types.FloatType
 import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.javacpp.IntPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class FloatValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+
+    public constructor(type: FloatType, value: Double) {
+        ref = LLVM.LLVMConstReal(type.ref, value)
+    }
+
     //region Core::Values::Constants::ScalarConstants
     /**
      * Obtains the double value for a floating point const value

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
@@ -3,8 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.javacpp.IntPointer
-import org.bytedeco.javacpp.Pointer
-import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
@@ -17,7 +15,7 @@ public class FloatValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
      */
     public fun getDouble(): Pair<Double, Boolean> {
         val ptr = IntPointer()
-        val double = LLVM.LLVMConstRealGetDouble(llvmValue, ptr)
+        val double = LLVM.LLVMConstRealGetDouble(ref, ptr)
 
         return (double) to (ptr.get().toBoolean())
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FunctionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FunctionValue.kt
@@ -6,7 +6,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class FunctionValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FunctionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FunctionValue.kt
@@ -5,7 +5,11 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class FunctionValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class FunctionValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 
     fun appendBasicBlock(name: String): BasicBlock {

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FunctionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FunctionValue.kt
@@ -6,6 +6,8 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class FunctionValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+
     fun appendBasicBlock(name: String): BasicBlock {
         return BasicBlock(LLVM.LLVMAppendBasicBlock(getUnderlyingReference(), name))
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/GenericValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/GenericValue.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 public class GenericValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/GenericValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/GenericValue.kt
@@ -3,6 +3,10 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class GenericValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class GenericValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/GenericValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/GenericValue.kt
@@ -3,4 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class GenericValue(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class GenericValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/GlobalValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/GlobalValue.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 public class GlobalValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/GlobalValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/GlobalValue.kt
@@ -3,6 +3,10 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class GlobalValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class GlobalValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/GlobalValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/GlobalValue.kt
@@ -3,4 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class GlobalValue(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class GlobalValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/InstructionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/InstructionValue.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 public class InstructionValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/InstructionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/InstructionValue.kt
@@ -3,4 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class InstructionValue(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class InstructionValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/InstructionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/InstructionValue.kt
@@ -3,6 +3,10 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class InstructionValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class InstructionValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -1,6 +1,5 @@
 package dev.supergrecko.kllvm.core.values
 
-import dev.supergrecko.kllvm.core.typedefs.Type
 import dev.supergrecko.kllvm.core.typedefs.Value
 import dev.supergrecko.kllvm.core.types.IntType
 import dev.supergrecko.kllvm.utils.toInt
@@ -8,28 +7,19 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class IntValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
 
-    //region Core::Values::Constants::ScalarConstants
-    public fun getIntZeroExtended(): Long {
-        return LLVM.LLVMConstIntGetZExtValue(ref)
+    /**
+     * @see [LLVM.LLVMConstInt]
+     */
+    public constructor(type: IntType, value: Long, signExtend: Boolean) {
+        ref = LLVM.LLVMConstInt(type.ref, value, signExtend.toInt())
     }
 
-    public fun getIntSignExtended(): Long {
-        return LLVM.LLVMConstIntGetSExtValue(ref)
-    }
-    //endregion Core::Values::Constants::ScalarConstants
-
-    companion object {
-        //region Core::Values::Constants::ScalarConstants
-        public fun new(type: Type, value: Long, signExtend: Boolean): IntValue {
-            return IntValue(
-                LLVM.LLVMConstInt(
-                    type.getUnderlyingReference(),
-                    value,
-                    signExtend.toInt()
-                )
-            )
-        }
-        //endregion Core::Values::Constants::ScalarConstants
+    /**
+     * @see [LLVM.LLVMConstIntOfArbitraryPrecision]
+     */
+    public constructor(type: IntType, words: List<Long>) {
+        ref = LLVM.LLVMConstIntOfArbitraryPrecision(type.ref, words.size, words.toLongArray())
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -11,11 +11,11 @@ public class IntValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
 
     //region Core::Values::Constants::ScalarConstants
     public fun getIntZeroExtended(): Long {
-        return LLVM.LLVMConstIntGetZExtValue(llvmValue)
+        return LLVM.LLVMConstIntGetZExtValue(ref)
     }
 
     public fun getIntSignExtended(): Long {
-        return LLVM.LLVMConstIntGetSExtValue(llvmValue)
+        return LLVM.LLVMConstIntGetSExtValue(ref)
     }
     //endregion Core::Values::Constants::ScalarConstants
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -6,20 +6,28 @@ import dev.supergrecko.kllvm.utils.toInt
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class IntValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class IntValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 
     /**
      * @see [LLVM.LLVMConstInt]
      */
-    public constructor(type: IntType, value: Long, signExtend: Boolean) {
+    public constructor(type: IntType, value: Long, signExtend: Boolean) : this() {
         ref = LLVM.LLVMConstInt(type.ref, value, signExtend.toInt())
     }
 
     /**
      * @see [LLVM.LLVMConstIntOfArbitraryPrecision]
      */
-    public constructor(type: IntType, words: List<Long>) {
-        ref = LLVM.LLVMConstIntOfArbitraryPrecision(type.ref, words.size, words.toLongArray())
+    public constructor(type: IntType, words: List<Long>) : this() {
+        ref = LLVM.LLVMConstIntOfArbitraryPrecision(
+            type.ref,
+            words.size,
+            words.toLongArray()
+        )
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -7,11 +7,11 @@ import org.bytedeco.llvm.global.LLVM
 public class IntValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
     //region Core::Values::Constants::ScalarConstants
     public fun getIntZeroExtended(): Long {
-        return LLVM.LLVMConstIntGetZExtValue(llvmValue)
+        return LLVM.LLVMConstIntGetZExtValue(ref)
     }
 
     public fun getIntSignExtended(): Long {
-        return LLVM.LLVMConstIntGetSExtValue(llvmValue)
+        return LLVM.LLVMConstIntGetSExtValue(ref)
     }
     //endregion Core::Values::Constants::ScalarConstants
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -7,7 +7,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class IntValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/MetadataValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/MetadataValue.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 public class MetadataValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/MetadataValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/MetadataValue.kt
@@ -3,4 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class MetadataValue(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class MetadataValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/MetadataValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/MetadataValue.kt
@@ -3,6 +3,10 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class MetadataValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class MetadataValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/PhiValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/PhiValue.kt
@@ -3,6 +3,10 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class PhiValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class PhiValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/PhiValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/PhiValue.kt
@@ -3,4 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class PhiValue(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class PhiValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/PhiValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/PhiValue.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 public class PhiValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/PointerValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/PointerValue.kt
@@ -3,4 +3,6 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class PointerValue(llvmValue: LLVMValueRef) : Value(llvmValue)
+public class PointerValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/PointerValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/PointerValue.kt
@@ -3,6 +3,10 @@ package dev.supergrecko.kllvm.core.values
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
-public class PointerValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class PointerValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/PointerValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/PointerValue.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 
 public class PointerValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
@@ -14,7 +14,7 @@ public class StructValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
      */
     @Shared
     public fun getElementAsConstant(index: Int): Value {
-        val value = LLVM.LLVMGetElementAsConstant(llvmValue, index)
+        val value = LLVM.LLVMGetElementAsConstant(ref, index)
 
         return Value(value)
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
@@ -10,7 +10,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class StructValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
@@ -9,25 +9,39 @@ import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class StructValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class StructValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 
     /**
      * @see [LLVM.LLVMConstStructInContext]
      */
-    public constructor(values: List<Value>, packed: Boolean, context: Context = Context.getGlobalContext()) {
+    public constructor(
+        values: List<Value>,
+        packed: Boolean,
+        context: Context = Context.getGlobalContext()
+    ) : this() {
         val ptr = ArrayList(values.map { it.ref }).toTypedArray()
 
-        ref = LLVM.LLVMConstStructInContext(context.ref, PointerPointer(*ptr), ptr.size, packed.toInt())
+        ref = LLVM.LLVMConstStructInContext(
+            context.ref,
+            PointerPointer(*ptr),
+            ptr.size,
+            packed.toInt()
+        )
     }
 
     /**
      * @see [LLVM.LLVMConstNamedStruct]
      */
-    public constructor(type: StructType, values: List<Value>) {
+    public constructor(type: StructType, values: List<Value>) : this() {
         val ptr = ArrayList(values.map { it.ref }).toTypedArray()
 
-        ref = LLVM.LLVMConstNamedStruct(type.ref, PointerPointer(*ptr), ptr.size)
+        ref =
+            LLVM.LLVMConstNamedStruct(type.ref, PointerPointer(*ptr), ptr.size)
     }
 
     //region Core::Values::Constants::CompositeConstants

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/StructValue.kt
@@ -1,11 +1,35 @@
 package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.annotations.Shared
+import dev.supergrecko.kllvm.core.typedefs.Context
 import dev.supergrecko.kllvm.core.typedefs.Value
+import dev.supergrecko.kllvm.core.types.StructType
+import dev.supergrecko.kllvm.utils.toInt
+import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class StructValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+
+    /**
+     * @see [LLVM.LLVMConstStructInContext]
+     */
+    public constructor(values: List<Value>, packed: Boolean, context: Context = Context.getGlobalContext()) {
+        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
+
+        ref = LLVM.LLVMConstStructInContext(context.ref, PointerPointer(*ptr), ptr.size, packed.toInt())
+    }
+
+    /**
+     * @see [LLVM.LLVMConstNamedStruct]
+     */
+    public constructor(type: StructType, values: List<Value>) {
+        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
+
+        ref = LLVM.LLVMConstNamedStruct(type.ref, PointerPointer(*ptr), ptr.size)
+    }
+
     //region Core::Values::Constants::CompositeConstants
     /**
      * Get an element at specified [index] as a constant

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -13,7 +13,7 @@ public class VectorValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
      */
     @Shared
     public fun getElementAsConstant(index: Int): Value {
-        val value = LLVM.LLVMGetElementAsConstant(llvmValue, index)
+        val value = LLVM.LLVMGetElementAsConstant(ref, index)
 
         return Value(value)
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -6,13 +6,17 @@ import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class VectorValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+public class VectorValue internal constructor() : Value() {
+    internal constructor(llvmValue: LLVMValueRef) : this() {
+        ref = llvmValue
+    }
+
     public constructor(value: Value) : this(value.ref)
 
     /**
      * @see [LLVM.LLVMConstVector]
      */
-    public constructor(values: List<Value>) {
+    public constructor(values: List<Value>) : this() {
         val ptr = ArrayList(values.map { it.ref }).toTypedArray()
 
         ref = LLVM.LLVMConstVector(PointerPointer(*ptr), ptr.size)

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -2,10 +2,22 @@ package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.annotations.Shared
 import dev.supergrecko.kllvm.core.typedefs.Value
+import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class VectorValue(llvmValue: LLVMValueRef) : Value(llvmValue) {
+    public constructor(value: Value) : this(value.ref)
+
+    /**
+     * @see [LLVM.LLVMConstVector]
+     */
+    public constructor(values: List<Value>) {
+        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
+
+        ref = LLVM.LLVMConstVector(PointerPointer(*ptr), ptr.size)
+    }
+
     /**
      * Get an element at specified [index] as a constant
      *

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -7,7 +7,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class VectorValue internal constructor() : Value() {
-    internal constructor(llvmValue: LLVMValueRef) : this() {
+    public constructor(llvmValue: LLVMValueRef) : this() {
         ref = llvmValue
     }
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/builders/BuilderTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/builders/BuilderTest.kt
@@ -17,14 +17,14 @@ import kotlin.test.assertNull
 class BuilderTest {
     @Test
     fun `should be able to position after basic blocks`() {
-        val builder = Builder.create()
+        val builder = Builder()
         assertNull(builder.getInsertBlock())
 
-        val module = Module.create("test.ll")
+        val module = Module("test.ll")
         val function = module.addFunction(
                 "test",
-                FunctionType.new(
-                        VoidType.new(),
+                FunctionType(
+                        VoidType(),
                         listOf(),
                         false))
 
@@ -44,7 +44,7 @@ class BuilderTest {
 
     @Test
     fun `should not be able to double free`() {
-        val builder = Builder.create()
+        val builder = Builder()
         builder.dispose()
 
         assertFailsWith<IllegalArgumentException> {
@@ -54,30 +54,30 @@ class BuilderTest {
 
     @Test
     fun `should create return instruction`() {
-        val builder = Builder.create()
-        val boolTy = IntType.new(1)
+        val builder = Builder()
+        val boolTy = IntType(1)
 
-        val instruction = builder.buildRet(IntValue.new(boolTy, value = 1, signExtend = false))
+        val instruction = builder.buildRet(IntValue(boolTy, value = 1, signExtend = false))
         assertEquals("ret i1 true", instruction.dumpToString().trim())
 
-        val instruction1 = builder.buildRet(IntValue.new(boolTy, value = 0, signExtend = false))
+        val instruction1 = builder.buildRet(IntValue(boolTy, value = 0, signExtend = false))
         assertEquals("ret i1 false", instruction1.dumpToString().trim())
     }
 
     @Test
     fun `should create call instruction`() {
-        val module = Module.create("test.ll")
-        val boolType = IntType.new(1)
+        val module = Module("test.ll")
+        val boolType = IntType(1)
         module.addFunction(
             "test",
-            FunctionType.new(boolType, listOf(boolType, boolType), false))
+            FunctionType(boolType, listOf(boolType, boolType), false))
         val externFunc = module.getFunction("test")
-        val builder = Builder.create()
-        val _false = IntValue.new(boolType, 0, false)
-        val _true = IntValue.new(boolType, 1, false)
+        val builder = Builder()
+        val _false = IntValue(boolType, 0, false)
+        val _true = IntValue(boolType, 1, false)
         val caller = module.addFunction(
             "caller",
-            FunctionType.new(boolType, listOf(boolType, boolType), false))
+            FunctionType(boolType, listOf(boolType, boolType), false))
         val basicBlock = caller.appendBasicBlock("entry")
         builder.positionAtEnd(basicBlock)
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/builders/BuilderTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/builders/BuilderTest.kt
@@ -30,7 +30,7 @@ class BuilderTest {
         // underlying reference is the same, the Builder object
         // that holds the reference is different
         // TODO?: Implement equals/hashCode for Builder by comparing underlying refs?
-        assertEquals(builder.getInsertBlock()?.llvmBlock, basicBlock.llvmBlock)
+        assertEquals(builder.getInsertBlock()?.ref, basicBlock.ref)
 
         builder.clearInsertPosition()
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/builders/BuilderTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/builders/BuilderTest.kt
@@ -35,7 +35,7 @@ class BuilderTest {
         // underlying reference is the same, the Builder object
         // that holds the reference is different
         // TODO?: Implement equals/hashCode for Builder by comparing underlying refs?
-        assertEquals(builder.getInsertBlock()?.llvmBlock, basicBlock.llvmBlock)
+        assertEquals(builder.getInsertBlock()?.ref, basicBlock.ref)
 
         builder.clearInsertPosition()
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/ContextTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFailsWith
 class ContextTest {
     @Test
     fun `fails to reuse dropped context`() {
-        val ctx = Context.create()
+        val ctx = Context()
         ctx.dispose()
 
         assertFailsWith<IllegalArgumentException> {
@@ -19,7 +19,7 @@ class ContextTest {
 
     @Test
     fun `dropping context twice fails`() {
-        val ctx = Context.create()
+        val ctx = Context()
 
         ctx.dispose()
 
@@ -30,7 +30,7 @@ class ContextTest {
 
     @Test
     fun `modifying discard value names actually works`() {
-        val ctx = Context.create()
+        val ctx = Context()
 
         runAll(true, false) {
             ctx.discardValueNames = it

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/modules/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/modules/ModuleTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertNull
 class ModuleTest {
     @Test
     fun `test that module identifiers match`() {
-        val mod = Module.create("test.ll")
+        val mod = Module("test.ll")
         mod.setModuleIdentifier("test")
 
         assertEquals("test", mod.getModuleIdentifier())
@@ -19,7 +19,7 @@ class ModuleTest {
 
     @Test
     fun `test that module cloning works`() {
-        val mod = Module.create("test.ll")
+        val mod = Module("test.ll")
         mod.setModuleIdentifier("test")
 
         val clone = mod.clone()
@@ -29,7 +29,7 @@ class ModuleTest {
 
     @Test
     fun `test that modifying source name works`() {
-        val mod = Module.create("test.ll")
+        val mod = Module("test.ll")
 
         assertEquals("test.ll", mod.getSourceFileName())
 
@@ -40,14 +40,14 @@ class ModuleTest {
 
     @Test
     fun `test getFunction returns null when no function added`() {
-        val module = Module.create("test.ll")
+        val module = Module("test.ll")
         assertNull(module.getFunction("test"))
     }
 
     @Test
     fun `test getFunction returns function object when function added`() {
-        val module = Module.create("test.ll")
-        module.addFunction("test", FunctionType.new(VoidType.new(), listOf(), false))
+        val module = Module("test.ll")
+        module.addFunction("test", FunctionType(VoidType(), listOf(), false))
         assertNotNull(module.getFunction("test"))
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/ArrayTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/ArrayTypeTest.kt
@@ -7,8 +7,8 @@ import kotlin.test.assertFailsWith
 class ArrayTypeTest {
     @Test
     fun `underlying type matches`() {
-        val type = IntType.new(32)
-        val arr = ArrayType.new(type, 10)
+        val type = IntType(32)
+        val arr = ArrayType(type, 10)
 
         assertEquals(10, arr.getElementCount())
         assertEquals(type.ref, arr.getElementType().ref)
@@ -16,8 +16,8 @@ class ArrayTypeTest {
 
     @Test
     fun `subtypes match`() {
-        val type = IntType.new(32)
-        val arr = ArrayType.new(type, 10)
+        val type = IntType(32)
+        val arr = ArrayType(type, 10)
 
         val children = arr.getSubtypes()
 
@@ -27,7 +27,7 @@ class ArrayTypeTest {
 
     @Test
     fun `negative size is illegal`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
 
         assertFailsWith<IllegalArgumentException> {
             type.toArrayType(-100)

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/ArrayTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/ArrayTypeTest.kt
@@ -11,7 +11,7 @@ class ArrayTypeTest {
         val arr = ArrayType.new(type, 10)
 
         assertEquals(10, arr.getElementCount())
-        assertEquals(type.llvmType, arr.getElementType().llvmType)
+        assertEquals(type.ref, arr.getElementType().ref)
     }
 
     @Test
@@ -22,7 +22,7 @@ class ArrayTypeTest {
         val children = arr.getSubtypes()
 
         assertEquals(10, children.size)
-        assertEquals(type.llvmType, children.first().llvmType)
+        assertEquals(type.ref, children.first().ref)
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/FunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/FunctionTypeTest.kt
@@ -14,7 +14,7 @@ class FunctionTypeTest {
         val fn = FunctionType.new(ret, listOf(), true)
 
         assertEquals(fn.getParameterCount(), 0)
-        assertTrue { fn.getReturnType().llvmType == ret.llvmType }
+        assertTrue { fn.getReturnType().ref == ret.ref }
     }
 
     @Test
@@ -32,7 +32,7 @@ class FunctionTypeTest {
         val args = listOf(FloatType.new(TypeKind.Float))
         val fn = FunctionType.new(ret, args, true)
 
-        assertEquals(LLVM.LLVMIsFunctionVarArg(fn.llvmType).toBoolean(), fn.isVariadic())
+        assertEquals(LLVM.LLVMIsFunctionVarArg(fn.ref).toBoolean(), fn.isVariadic())
     }
 
     @Test
@@ -41,7 +41,7 @@ class FunctionTypeTest {
         val args = listOf(FloatType.new(TypeKind.Float))
         val fn = FunctionType.new(ret, args, true)
 
-        assertEquals(LLVM.LLVMCountParamTypes(fn.llvmType), fn.getParameterCount())
+        assertEquals(LLVM.LLVMCountParamTypes(fn.ref), fn.getParameterCount())
     }
 
     @Test
@@ -53,8 +53,8 @@ class FunctionTypeTest {
         val params = fn.getParameterTypes()
 
         for (i in args.indices) {
-            val x = params[i].llvmType
-            val y = params[i].llvmType
+            val x = params[i].ref
+            val y = params[i].ref
             assertEquals(x, y)
         }
     }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/FunctionTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/FunctionTypeTest.kt
@@ -10,8 +10,8 @@ import kotlin.test.assertTrue
 class FunctionTypeTest {
     @Test
     fun `creation of zero arg type works`() {
-        val ret = IntType.new(64)
-        val fn = FunctionType.new(ret, listOf(), true)
+        val ret = IntType(64)
+        val fn = FunctionType(ret, listOf(), true)
 
         assertEquals(fn.getParameterCount(), 0)
         assertTrue { fn.getReturnType().ref == ret.ref }
@@ -19,36 +19,36 @@ class FunctionTypeTest {
 
     @Test
     fun `variadic arguments work`() {
-        val ret = IntType.new(64)
-        val args = listOf(FloatType.new(TypeKind.Float))
-        val fn = FunctionType.new(ret, args, true)
+        val ret = IntType(64)
+        val args = listOf(FloatType(TypeKind.Float))
+        val fn = FunctionType(ret, args, true)
 
         assertEquals(fn.isVariadic(), true)
     }
 
     @Test
     fun `test variadic wrapper works`() {
-        val ret = IntType.new(64)
-        val args = listOf(FloatType.new(TypeKind.Float))
-        val fn = FunctionType.new(ret, args, true)
+        val ret = IntType(64)
+        val args = listOf(FloatType(TypeKind.Float))
+        val fn = FunctionType(ret, args, true)
 
         assertEquals(LLVM.LLVMIsFunctionVarArg(fn.ref).toBoolean(), fn.isVariadic())
     }
 
     @Test
     fun `test parameter count wrapper works`() {
-        val ret = IntType.new(64)
-        val args = listOf(FloatType.new(TypeKind.Float))
-        val fn = FunctionType.new(ret, args, true)
+        val ret = IntType(64)
+        val args = listOf(FloatType(TypeKind.Float))
+        val fn = FunctionType(ret, args, true)
 
         assertEquals(LLVM.LLVMCountParamTypes(fn.ref), fn.getParameterCount())
     }
 
     @Test
     fun `test parameter list matches`() {
-        val ret = IntType.new(64)
-        val args = listOf(FloatType.new(TypeKind.Float))
-        val fn = FunctionType.new(ret, args, true)
+        val ret = IntType(64)
+        val args = listOf(FloatType(TypeKind.Float))
+        val fn = FunctionType(ret, args, true)
 
         val params = fn.getParameterTypes()
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/IntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/IntegerTypeTest.kt
@@ -9,11 +9,11 @@ import kotlin.test.assertTrue
 class IntegerTypeTest {
     @Test
     fun `global module values equate to module values`() {
-        val ctx = Context.create()
+        val ctx = Context()
 
         runAll(1, 8, 16, 32, 64, 128) {
-            val contextType = IntType.new(it, ctx)
-            val globalType = IntType.new(it)
+            val contextType = IntType(it, ctx)
+            val globalType = IntType(it)
 
             assertEquals(contextType.getTypeWidth(), globalType.getTypeWidth())
         }
@@ -21,10 +21,10 @@ class IntegerTypeTest {
 
     @Test
     fun `it actually grabs types instead of null pointers`() {
-        val ctx = Context.create()
+        val ctx = Context()
 
         runAll(1, 8, 16, 32, 64, 128) {
-            val type = IntType.new(it, ctx)
+            val type = IntType(it, ctx)
 
             assertTrue { !type.ref.isNull }
         }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/IntegerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/IntegerTypeTest.kt
@@ -26,7 +26,7 @@ class IntegerTypeTest {
         runAll(1, 8, 16, 32, 64, 128) {
             val type = IntType.new(it, ctx)
 
-            assertTrue { !type.llvmType.isNull }
+            assertTrue { !type.ref.isNull }
         }
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/PointerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/PointerTypeTest.kt
@@ -9,7 +9,7 @@ class PointerTypeTest {
         val type = IntType.new(32)
         val ptr = type.toPointerType()
 
-        assertEquals(type.llvmType, ptr.getElementType().llvmType)
+        assertEquals(type.ref, ptr.getElementType().ref)
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/PointerTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/PointerTypeTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 class PointerTypeTest {
     @Test
     fun `underlying type matches`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val ptr = type.toPointerType()
 
         assertEquals(type.ref, ptr.getElementType().ref)
@@ -14,7 +14,7 @@ class PointerTypeTest {
 
     @Test
     fun `subtype matches`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val ptr = type.toPointerType()
 
         assertEquals(type.getTypeKind(), ptr.getSubtypes().first().getTypeKind())
@@ -22,14 +22,14 @@ class PointerTypeTest {
 
     @Test
     fun `count matches`() {
-        val type = IntType.new(32).toPointerType()
+        val type = IntType(32).toPointerType()
 
         assertEquals(1, type.getElementCount())
     }
 
     @Test
     fun `address space matches`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val ptr = type.toPointerType(100)
 
         assertEquals(100, ptr.getAddressSpace())

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/StructureTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/StructureTypeTest.kt
@@ -15,10 +15,10 @@ class StructureTypeTest {
         assertEquals(false, struct.isOpaque())
 
         val (first) = struct.getElementTypes()
-        assertEquals(elements.first().llvmType, first.llvmType)
+        assertEquals(elements.first().ref, first.ref)
 
         val type = struct.getElementTypeAt(0)
-        assertEquals(type.llvmType, elements.first().llvmType)
+        assertEquals(type.ref, elements.first().ref)
     }
 
     @Test
@@ -38,7 +38,7 @@ class StructureTypeTest {
         struct.setBody(elements, false)
 
         val (first) = struct.getElementTypes()
-        assertEquals(elements.first().llvmType, first.llvmType)
+        assertEquals(elements.first().ref, first.ref)
         assertEquals(false, struct.isOpaque())
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/StructureTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/StructureTypeTest.kt
@@ -6,8 +6,8 @@ import kotlin.test.assertEquals
 class StructureTypeTest {
     @Test
     fun `test element spec matches`() {
-        val elements = listOf(IntType.new(32))
-        val struct = StructType.new(elements, false)
+        val elements = listOf(IntType(32))
+        val struct = StructType(elements, false)
 
         assertEquals(false, struct.isPacked())
         assertEquals(1, struct.getElementCount())
@@ -23,18 +23,18 @@ class StructureTypeTest {
 
     @Test
     fun `name matches`() {
-        val struct = StructType.opaque("StructureName")
+        val struct = StructType("StructureName")
 
         assertEquals("StructureName", struct.getName())
     }
 
     @Test
     fun `test opaque struct`() {
-        val struct = StructType.opaque("test_struct")
+        val struct = StructType("test_struct")
 
         assertEquals(true, struct.isOpaque())
 
-        val elements = listOf(IntType.new(32))
+        val elements = listOf(IntType(32))
         struct.setBody(elements, false)
 
         val (first) = struct.getElementTypes()

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/TypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/TypeTest.kt
@@ -95,7 +95,7 @@ class TypeTest {
 
         val typeCtx = type.getContext()
 
-        assertEquals(ctx.llvmCtx, typeCtx.llvmCtx)
+        assertEquals(ctx.ref, typeCtx.ref)
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/TypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/TypeTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFailsWith
 class TypeTest {
     @Test
     fun `test creation of pointer type`() {
-        val type = IntType.new(64)
+        val type = IntType(64)
         val ptr = type.toPointerType()
 
         assertEquals(TypeKind.Pointer, ptr.getTypeKind())
@@ -17,7 +17,7 @@ class TypeTest {
 
     @Test
     fun `test creation of array type`() {
-        val type = IntType.new(64)
+        val type = IntType(64)
         val arr = type.toArrayType(10)
 
         assertEquals(TypeKind.Array, arr.getTypeKind())
@@ -26,7 +26,7 @@ class TypeTest {
 
     @Test
     fun `test creation of vector type`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val vec = type.toVectorType(1000)
 
         assertEquals(TypeKind.Vector, vec.getTypeKind())
@@ -35,26 +35,26 @@ class TypeTest {
 
     @Test
     fun `casting into other type works when expected to`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val ptr = type.toPointerType()
         val underlying = ptr.getElementType()
 
-        assertEquals(type.ref, underlying.cast<IntType>().llvmType)
+        assertEquals(type.ref, IntType(underlying).ref)
     }
 
     @Test
     fun `casting won't fail when the underlying type is different`() {
         // it is impossible to guarantee that the underlying types is valid or invalid
-        val type = IntType.new(32)
+        val type = IntType(32)
         val ptr = type.toPointerType()
         val underlying = ptr.getElementType()
 
-        assertEquals(type.ref, underlying.cast<FunctionType>().llvmType)
+        assertEquals(type.ref, FunctionType(underlying).ref)
     }
 
     @Test
     fun `getting a type works properly`() {
-        val type = FloatType.new(TypeKind.Float)
+        val type = FloatType(TypeKind.Float)
 
         assertEquals(TypeKind.Float, type.getTypeKind())
     }
@@ -62,36 +62,36 @@ class TypeTest {
     @Test
     fun `negative size is illegal`() {
         assertFailsWith<IllegalArgumentException> {
-            IntType.new(-1)
+            IntType(-1)
         }
     }
 
     @Test
     fun `too huge size is illegal`() {
         assertFailsWith<IllegalArgumentException> {
-            IntType.new(1238234672)
+            IntType(1238234672)
         }
     }
 
     @Test
     fun `is sized works for integer`() {
-        val type = IntType.new(192)
+        val type = IntType(192)
 
         assertEquals(true, type.isSized())
     }
 
     @Test
     fun `is sized works for struct`() {
-        val arg = FloatType.new(TypeKind.Float)
-        val type = StructType.new(listOf(arg), false)
+        val arg = FloatType(TypeKind.Float)
+        val type = StructType(listOf(arg), false)
 
         assertEquals(true, type.isSized())
     }
 
     @Test
     fun `retrieving context works`() {
-        val ctx = Context.create()
-        val type = IntType.new(32, ctx)
+        val ctx = Context()
+        val type = IntType(32, ctx)
 
         val typeCtx = type.getContext()
 
@@ -100,7 +100,7 @@ class TypeTest {
 
     @Test
     fun `getting a name representation works`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
 
         val msg = type.getStringRepresentation()
 

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/TypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/TypeTest.kt
@@ -39,7 +39,7 @@ class TypeTest {
         val ptr = type.toPointerType()
         val underlying = ptr.getElementType()
 
-        assertEquals(type.llvmType, underlying.cast<IntType>().llvmType)
+        assertEquals(type.ref, underlying.cast<IntType>().llvmType)
     }
 
     @Test
@@ -49,7 +49,7 @@ class TypeTest {
         val ptr = type.toPointerType()
         val underlying = ptr.getElementType()
 
-        assertEquals(type.llvmType, underlying.cast<FunctionType>().llvmType)
+        assertEquals(type.ref, underlying.cast<FunctionType>().llvmType)
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/VectorTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/VectorTypeTest.kt
@@ -12,7 +12,7 @@ class VectorTypeTest {
         val vec = VectorType.new(type, 10)
 
         assertEquals(10, vec.getElementCount())
-        assertEquals(type.llvmType, vec.getElementType().llvmType)
+        assertEquals(type.ref, vec.getElementType().ref)
     }
 
     @Test
@@ -21,7 +21,7 @@ class VectorTypeTest {
         val vec = VectorType.new(type, 10)
 
         assertEquals(10, vec.getSubtypes().size)
-        assertEquals(type.llvmType, vec.getSubtypes().first().llvmType)
+        assertEquals(type.ref, vec.getSubtypes().first().ref)
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/types/VectorTypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/types/VectorTypeTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.assertFailsWith
 class VectorTypeTest {
     @Test
     fun `underlying type matches`() {
-        val type = IntType.new(32)
-        val vec = VectorType.new(type, 10)
+        val type = IntType(32)
+        val vec = VectorType(type, 10)
 
         assertEquals(10, vec.getElementCount())
         assertEquals(type.ref, vec.getElementType().ref)
@@ -17,8 +17,8 @@ class VectorTypeTest {
 
     @Test
     fun `subtypes match`() {
-        val type = IntType.new(32)
-        val vec = VectorType.new(type, 10)
+        val type = IntType(32)
+        val vec = VectorType(type, 10)
 
         assertEquals(10, vec.getSubtypes().size)
         assertEquals(type.ref, vec.getSubtypes().first().ref)
@@ -26,14 +26,14 @@ class VectorTypeTest {
 
     @Test
     fun `negative size is illegal`() {
-        val type = FloatType.new(TypeKind.Float)
+        val type = FloatType(TypeKind.Float)
 
         assertFailsWith<IllegalArgumentException> {
             type.toVectorType(-100)
         }
 
         assertFailsWith<IllegalArgumentException> {
-            VectorType.new(type, -100)
+            VectorType(type, -100)
         }
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/values/ValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/values/ValueTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 class ValueTest {
     @Test
     fun `creating const all one type works`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val value = type.getConstantAllOnes()
 
         assertEquals(ValueKind.ConstantInt, value.getValueKind())
@@ -16,7 +16,7 @@ class ValueTest {
 
     @Test
     fun `creating zero value works`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val value = type.getConstantNull()
 
         assertEquals(ValueKind.ConstantInt, value.getValueKind())
@@ -24,7 +24,7 @@ class ValueTest {
 
     @Test
     fun `null pointer creation works`() {
-        val type = IntType.new(32)
+        val type = IntType(32)
         val nullptr = type.getConstantNullPointer()
 
         assertEquals(ValueKind.ConstantPointerNull, nullptr.getValueKind())
@@ -32,7 +32,7 @@ class ValueTest {
 
     @Test
     fun `creation of undefined type object works`() {
-        val type = IntType.new(1032)
+        val type = IntType(1032)
         val undef = type.getConstantUndef()
 
         assertEquals(ValueKind.UndefValue, undef.getValueKind())


### PR DESCRIPTION
This begins implementing the parts discussed in #62 where we decided to use secondary constructors for creation of objects instead of member methods on classes

**Major Changes**
- Everything which used to be .llvm* to represent the LLVM references are now just .ref
- Remove most companion object constructors for secondary constructors

**Pros**
- Offers the same APIs as before
- Gets rid of all usage of Reflection for casting

**Cons**
- Need to be a lot more careful about declaring constructors now
- Uses lateinit var, need to logically ensure things are actually set