### PR TITLE
[api] Implement ConstantExpression apis

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Type.kt
@@ -3,6 +3,7 @@ package dev.supergrecko.kllvm.core.typedefs
 import dev.supergrecko.kllvm.core.enumerations.TypeKind
 import dev.supergrecko.kllvm.core.message.Message
 import dev.supergrecko.kllvm.core.types.*
+import dev.supergrecko.kllvm.core.values.IntValue
 import dev.supergrecko.kllvm.utils.toBoolean
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
@@ -79,6 +80,26 @@ public open class Type internal constructor() {
         return Value(LLVM.LLVMConstPointerNull(ref))
     }
     //endregion Core::Values::Constants
+
+    //region Core::Values::Constants::ConstantExpressions
+    /**
+     * @see [LLVM.LLVMAlignOf]
+     */
+    public fun alignOf(): IntValue {
+        val ref = LLVM.LLVMAlignOf(ref)
+
+        return IntValue(ref)
+    }
+
+    /**
+     * @see [LLVM.LLVMSizeOf]
+     */
+    public fun sizeOf(): IntValue {
+        val ref = LLVM.LLVMSizeOf(ref)
+
+        return IntValue(ref)
+    }
+    //endregion Core::Values::Constants::ConstantExpressions
 
     //region Typecasting
     public fun toPointerType(addressSpace: Int = 0): PointerType =

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/typedefs/Value.kt
@@ -1,9 +1,12 @@
 package dev.supergrecko.kllvm.core.typedefs
 
 import dev.supergrecko.kllvm.contracts.Unreachable
+import dev.supergrecko.kllvm.core.enumerations.Opcode
 import dev.supergrecko.kllvm.core.enumerations.ThreadLocalMode
 import dev.supergrecko.kllvm.core.enumerations.ValueKind
+import dev.supergrecko.kllvm.core.types.IntType
 import dev.supergrecko.kllvm.core.types.PointerType
+import dev.supergrecko.kllvm.core.values.IntValue
 import dev.supergrecko.kllvm.core.values.PointerValue
 import dev.supergrecko.kllvm.utils.toBoolean
 import dev.supergrecko.kllvm.utils.toInt
@@ -152,6 +155,21 @@ public open class Value internal constructor() {
         return PointerValue(LLVM.LLVMConstPointerCast(ref, toType.ref))
     }
     //endregion Core::Values::Constants
+
+    //region Core::Values::Constants::ConstantExpressions
+    /**
+     * @see [LLVM.LLVMGetConstOpcode]
+     */
+    public fun getOpcode(): Opcode {
+        require(isConstant())
+
+        val int = LLVM.LLVMGetConstOpcode(ref)
+
+        return Opcode.values()
+            .firstOrNull { it.value == int }
+            ?: throw Unreachable()
+    }
+    //endregion Core::Values::Constants::ConstantExpressions
 
     public fun getUnderlyingReference(): LLVMValueRef = ref
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
@@ -53,6 +53,7 @@ public class FloatValue internal constructor() : Value() {
      */
     public fun add(v: FloatValue): FloatValue {
         require(isConstant())
+        require(getType().getTypeKind() == v.getType().getTypeKind())
 
         val ref = LLVM.LLVMConstFAdd(ref, v.ref)
 
@@ -67,6 +68,7 @@ public class FloatValue internal constructor() : Value() {
      */
     public fun sub(v: FloatValue): FloatValue {
         require(isConstant())
+        require(getType().getTypeKind() == v.getType().getTypeKind())
 
         val ref = LLVM.LLVMConstFSub(ref, v.ref)
 
@@ -81,10 +83,25 @@ public class FloatValue internal constructor() : Value() {
      */
     public fun mul(v: FloatValue): FloatValue {
         require(isConstant())
+        require(getType().getTypeKind() == v.getType().getTypeKind())
 
         val ref = LLVM.LLVMConstMul(ref, v.ref)
 
         return FloatValue(ref)
+    }
+
+    /**
+     * Perform division with another float
+     *
+     * TODO: Find a way to return something more exact than Value
+     */
+    public fun div(v: FloatValue): Value {
+        require(isConstant())
+        require(getType().getTypeKind() == v.getType().getTypeKind())
+
+        val ref = LLVM.LLVMConstFDiv(ref, v.ref)
+
+        return Value(ref)
     }
     //endregion Core::Values::Constants::ConstantExpressions
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
@@ -31,6 +31,12 @@ public class FloatValue internal constructor() : Value() {
     //endregion Core::Values::Constants::ScalarConstants
 
     //region Core::Values::Constants::ConstantExpressions
+    /**
+     * Negate this float
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     */
     public fun neg(): FloatValue {
         require(isConstant())
 
@@ -39,6 +45,12 @@ public class FloatValue internal constructor() : Value() {
         return FloatValue(ref)
     }
 
+    /**
+     * Add another float to this float
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     */
     public fun add(v: FloatValue): FloatValue {
         require(isConstant())
 
@@ -47,6 +59,12 @@ public class FloatValue internal constructor() : Value() {
         return FloatValue(ref)
     }
 
+    /**
+     * Subtract another float from this float
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     */
     public fun sub(v: FloatValue): FloatValue {
         require(isConstant())
 
@@ -55,6 +73,12 @@ public class FloatValue internal constructor() : Value() {
         return FloatValue(ref)
     }
 
+    /**
+     * Multiply this float with another float
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     */
     public fun mul(v: FloatValue): FloatValue {
         require(isConstant())
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/FloatValue.kt
@@ -29,4 +29,38 @@ public class FloatValue internal constructor() : Value() {
         return (double) to (ptr.get().toBoolean())
     }
     //endregion Core::Values::Constants::ScalarConstants
+
+    //region Core::Values::Constants::ConstantExpressions
+    public fun neg(): FloatValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstFNeg(ref)
+
+        return FloatValue(ref)
+    }
+
+    public fun add(v: FloatValue): FloatValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstFAdd(ref, v.ref)
+
+        return FloatValue(ref)
+    }
+
+    public fun sub(v: FloatValue): FloatValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstFSub(ref, v.ref)
+
+        return FloatValue(ref)
+    }
+
+    public fun mul(v: FloatValue): FloatValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstMul(ref, v.ref)
+
+        return FloatValue(ref)
+    }
+    //endregion Core::Values::Constants::ConstantExpressions
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -12,6 +12,11 @@ public class IntValue internal constructor() : Value() {
     }
 
     /**
+     * Create a new integer value of type [type]
+     *
+     * This creates a new integer from [type] with [value]. You can decide if
+     * this is signed with [signExtend].
+     *
      * @see [LLVM.LLVMConstInt]
      */
     public constructor(
@@ -23,7 +28,11 @@ public class IntValue internal constructor() : Value() {
     }
 
     /**
-     * @see [LLVM.LLVMConstIntOfArbitraryPrecision]
+     * Create a constant integer of arbitrary precision
+     *
+     * TODO: Find out [words] actually is ... and how to properly use this
+     *
+     * @see LLVM.LLVMConstIntOfArbitraryPrecision
      */
     public constructor(type: IntType, words: List<Long>) : this() {
         ref = LLVM.LLVMConstIntOfArbitraryPrecision(
@@ -35,9 +44,20 @@ public class IntValue internal constructor() : Value() {
 
     //region Core::Values::Constants::ConstantExpressions
     /**
-     * Negate the value
+     * Negate the constant value
      *
-     * @see [LLVM.LLVMConstNeg]
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     *
+     * LLVM doesn't actually have a neg instruction, but it's implemented using
+     * subtraction. It subtracts the value of max value of the type of the value
+     *
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     *
+     * @see LLVM.LLVMConstNeg
      */
     public fun neg(hasNUW: Boolean = false, hasNSW: Boolean = false): IntValue {
         require(isConstant())
@@ -53,7 +73,15 @@ public class IntValue internal constructor() : Value() {
     }
 
     /**
-     * @see [LLVM.LLVMConstNot]
+     * Invert the integer value using XOR
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     *
+     * This in short performs the same action as [neg] but instead of using
+     * subtraction it uses a bitwise XOR where B is always true.
+     *
+     * @see LLVM.LLVMConstNot
      */
     public fun not(): IntValue {
         require(isConstant())
@@ -63,6 +91,22 @@ public class IntValue internal constructor() : Value() {
         return IntValue(ref)
     }
 
+    /**
+     * Add another value to this integer
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     *
+     * If the sum has unsigned overflow, the result returned is the
+     * mathematical result modulo 2n, where n is the bit width of the result.
+     *
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     *
+     * @see LLVM.LLVMConstAdd
+     */
     public fun add(
         v: IntValue,
         hasNUW: Boolean = false,
@@ -80,6 +124,20 @@ public class IntValue internal constructor() : Value() {
         return IntValue(ref)
     }
 
+    /**
+     * Subtract another value from this integer
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     *
+     * If the sum has unsigned overflow, the result returned is the
+     * mathematical result modulo 2n, where n is the bit width of the result.
+     *
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     */
     public fun sub(
         v: IntValue,
         hasNUW: Boolean = false,
@@ -97,6 +155,20 @@ public class IntValue internal constructor() : Value() {
         return IntValue(ref)
     }
 
+    /**
+     * Multiply another value with this integer
+     *
+     * This value is not modified, but it returns a new value with the result of
+     * the operation.
+     *
+     * If the sum has unsigned overflow, the result returned is the
+     * mathematical result modulo 2n, where n is the bit width of the result.
+     *
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     */
     public fun mul(
         v: IntValue,
         hasNUW: Boolean = false,

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.contracts.Unreachable
+import dev.supergrecko.kllvm.core.enumerations.IntPredicate
 import dev.supergrecko.kllvm.core.typedefs.Value
 import dev.supergrecko.kllvm.core.types.IntType
 import dev.supergrecko.kllvm.utils.toInt
@@ -237,13 +238,93 @@ public class IntValue internal constructor() : Value() {
      * If [unsigned] is present, URem will be used
      */
     public fun rem(v: IntValue, unsigned: Boolean): IntValue {
-        require(isConstant())
+        require(isConstant() && v.isConstant())
 
         val ref = if (unsigned) {
             LLVM.LLVMConstURem(ref, v.ref)
         } else {
             LLVM.LLVMConstSRem(ref, v.ref)
         }
+
+        return IntValue(ref)
+    }
+
+    public fun and(v: IntValue): IntValue {
+        require(isConstant() && v.isConstant())
+
+        val ref = LLVM.LLVMConstAnd(ref, v.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun or(v: IntValue): IntValue {
+        require(isConstant() && v.isConstant())
+
+        val ref = LLVM.LLVMConstOr(ref, v.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun xor(v: IntValue): IntValue {
+        require(isConstant() && v.isConstant())
+
+        val ref = LLVM.LLVMConstXor(ref, v.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun cmp(predicate: IntPredicate, v: IntValue): IntValue {
+        require(isConstant() && v.isConstant())
+
+        val ref = LLVM.LLVMConstICmp(predicate.value, ref, v.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun shl(v: IntValue): IntValue {
+        require(isConstant() && v.isConstant())
+
+        val ref = LLVM.LLVMConstShl(ref, v.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun lshr(v: IntValue): IntValue {
+        require(isConstant() && v.isConstant())
+
+        val ref = LLVM.LLVMConstLShr(ref, v.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun ashr(v: IntValue): IntValue {
+        require(isConstant() && v.isConstant())
+
+        val ref = LLVM.LLVMConstAShr(ref, v.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun trunc(type: IntType): IntValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstTrunc(ref, type.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun sext(type: IntType): IntValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstSExt(ref, type.ref)
+
+        return IntValue(ref)
+    }
+
+    public fun zext(type: IntType): IntValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstZExt(ref, type.ref)
 
         return IntValue(ref)
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -42,6 +42,22 @@ public class IntValue internal constructor() : Value() {
         )
     }
 
+    //region Core::Values::Constants::ScalarConstants
+    /**
+     * @see LLVM.LLVMConstIntGetZExtValue
+     */
+    public fun getUnsignedValue(): Long {
+        return LLVM.LLVMConstIntGetZExtValue(ref)
+    }
+
+    /**
+     * @see LLVM.LLVMConstIntGetSExtValue
+     */
+    public fun getSignedValue(): Long {
+        return LLVM.LLVMConstIntGetSExtValue(ref)
+    }
+    //endregion  Core::Values::Constants::ScalarConstants
+
     //region Core::Values::Constants::ConstantExpressions
     /**
      * Negate the constant value

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -185,5 +185,53 @@ public class IntValue internal constructor() : Value() {
 
         return IntValue(ref)
     }
+
+    /**
+     * Perform division with another signed integer
+     *
+     * Division by zero is undefined behavior. For vectors, if any element of
+     * the divisor is zero, the operation has undefined behavior. Overflow also
+     * leads to undefined behavior; this is a rare case, but can occur,
+     * for example, by doing a 32-bit division of -2147483648 by -1.
+     *
+     * If the [exact] arg is present, the result value of the sdiv is a poison
+     * value if the result would be rounded.
+     *
+     * TODO: Find a way to return something more exact than Value
+     */
+    public fun sdiv(v: IntValue, exact: Boolean): Value {
+        require(isConstant())
+
+        val ref = if (exact) {
+            LLVM.LLVMConstExactSDiv(ref, v.ref)
+        } else {
+            LLVM.LLVMConstSDiv(ref, v.ref)
+        }
+
+        return IntValue(ref)
+    }
+
+    /**
+     * Perform division with another unsigned integer
+     *
+     * Division by zero is undefined behavior. For vectors, if any element of
+     * the divisor is zero, the operation has undefined behavior
+     *
+     * If the [exact] arg is present, the result value of the udiv is a poison
+     * value if %op1 is not a multiple of %op2, eg "((a udiv exact b) mul b) == a".
+     *
+     * TODO: Find a way to return something more exact than Value
+     */
+    public fun udiv(v: IntValue, exact: Boolean): Value {
+        require(isConstant())
+
+        val ref = if (exact) {
+            LLVM.LLVMConstExactUDiv(ref, v.ref)
+        } else {
+            LLVM.LLVMConstUDiv(ref, v.ref)
+        }
+
+        return Value(ref)
+    }
     //endregion Core::Values::Constants::ConstantExpressions
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -94,9 +94,6 @@ public class IntValue internal constructor() : Value() {
      * This value is not modified, but it returns a new value with the result of
      * the operation.
      *
-     * This in short performs the same action as [neg] but instead of using
-     * subtraction it uses a bitwise XOR where B is always true.
-     *
      * @see LLVM.LLVMConstNot
      */
     public fun not(): IntValue {
@@ -214,8 +211,9 @@ public class IntValue internal constructor() : Value() {
      * value if the result would be rounded.
      *
      * TODO: Find a way to return something more exact than Value
+     * TODO: Find a way to determine if type is unsigned
      */
-    public fun sdiv(v: IntValue, exact: Boolean): Value {
+    public fun sdiv(v: IntValue, exact: Boolean): IntValue {
         require(isConstant())
 
         val ref = if (exact) {
@@ -236,9 +234,9 @@ public class IntValue internal constructor() : Value() {
      * If the [exact] arg is present, the result value of the udiv is a poison
      * value if %op1 is not a multiple of %op2, eg "((a udiv exact b) mul b) == a".
      *
-     * TODO: Find a way to return something more exact than Value
+     * TODO: Find a way to determine if type is unsigned
      */
-    public fun udiv(v: IntValue, exact: Boolean): Value {
+    public fun udiv(v: IntValue, exact: Boolean): IntValue {
         require(isConstant())
 
         val ref = if (exact) {
@@ -247,7 +245,7 @@ public class IntValue internal constructor() : Value() {
             LLVM.LLVMConstUDiv(ref, v.ref)
         }
 
-        return Value(ref)
+        return IntValue(ref)
     }
     //endregion Core::Values::Constants::ConstantExpressions
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/IntValue.kt
@@ -14,7 +14,11 @@ public class IntValue internal constructor() : Value() {
     /**
      * @see [LLVM.LLVMConstInt]
      */
-    public constructor(type: IntType, value: Long, signExtend: Boolean) : this() {
+    public constructor(
+        type: IntType,
+        value: Long,
+        signExtend: Boolean
+    ) : this() {
         ref = LLVM.LLVMConstInt(type.ref, value, signExtend.toInt())
     }
 
@@ -28,4 +32,86 @@ public class IntValue internal constructor() : Value() {
             words.toLongArray()
         )
     }
+
+    //region Core::Values::Constants::ConstantExpressions
+    /**
+     * Negate the value
+     *
+     * @see [LLVM.LLVMConstNeg]
+     */
+    public fun neg(hasNUW: Boolean = false, hasNSW: Boolean = false): IntValue {
+        require(isConstant())
+        require(!(hasNSW && hasNSW)) { "Cannot negate with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWNeg(ref)
+            hasNUW -> LLVM.LLVMConstNUWNeg(ref)
+            else -> LLVM.LLVMConstNeg(ref)
+        }
+
+        return IntValue(ref)
+    }
+
+    /**
+     * @see [LLVM.LLVMConstNot]
+     */
+    public fun not(): IntValue {
+        require(isConstant())
+
+        val ref = LLVM.LLVMConstNot(ref)
+
+        return IntValue(ref)
+    }
+
+    public fun add(
+        v: IntValue,
+        hasNUW: Boolean = false,
+        hasNSW: Boolean = false
+    ): IntValue {
+        require(isConstant() && v.isConstant())
+        require(!(hasNSW && hasNSW)) { "Cannot add with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWAdd(ref, v.ref)
+            hasNUW -> LLVM.LLVMConstNUWAdd(ref, v.ref)
+            else -> LLVM.LLVMConstAdd(ref, v.ref)
+        }
+
+        return IntValue(ref)
+    }
+
+    public fun sub(
+        v: IntValue,
+        hasNUW: Boolean = false,
+        hasNSW: Boolean = false
+    ): IntValue {
+        require(isConstant() && v.isConstant())
+        require(!(hasNSW && hasNSW)) { "Cannot sub with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWSub(ref, v.ref)
+            hasNUW -> LLVM.LLVMConstNUWSub(ref, v.ref)
+            else -> LLVM.LLVMConstSub(ref, v.ref)
+        }
+
+        return IntValue(ref)
+    }
+
+    public fun mul(
+        v: IntValue,
+        hasNUW: Boolean = false,
+        hasNSW: Boolean = false
+    ): IntValue {
+        require(isConstant() && v.isConstant())
+        require(!(hasNSW && hasNSW)) { "Cannot sub with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWMul(ref, v.ref)
+            hasNUW -> LLVM.LLVMConstNUWMul(ref, v.ref)
+            else -> LLVM.LLVMConstMul(ref, v.ref)
+        }
+
+        return IntValue(ref)
+    }
+    //endregion Core::Values::Constants::ConstantExpressions
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -35,11 +35,17 @@ public class VectorValue internal constructor() : Value() {
 
     //region Core::Values::Constants::ConstantExpressions
     /**
-     * Negate all the values in the vector
+     * Negate the constant value
      *
-     * This operation is only valid on Vectors of Integers. Use FNeg for floats
+     * LLVM doesn't actually have a neg instruction, but it's implemented using
+     * subtraction. It subtracts the value of max value of the type of the value
      *
-     * @see [LLVM.LLVMConstNeg]
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     *
+     * @see LLVM.LLVMConstNeg
      */
     public fun neg(
         hasNUW: Boolean = false,
@@ -58,6 +64,14 @@ public class VectorValue internal constructor() : Value() {
         return VectorValue(ref)
     }
 
+    /**
+     * Invert each integer value using XOR
+     *
+     * This in short performs the same action as [neg] but instead of using
+     * subtraction it uses a bitwise XOR where B is always true.
+     *
+     * @see LLVM.LLVMConstNot
+     */
     public fun not(): VectorValue {
         require(isConstant())
         require(getType().getTypeKind() == TypeKind.Integer)
@@ -67,6 +81,19 @@ public class VectorValue internal constructor() : Value() {
         return VectorValue(ref)
     }
 
+    /**
+     * Add another value to this vector of integers
+     *
+     * If the sum has unsigned overflow, the result returned is the
+     * mathematical result modulo 2n, where n is the bit width of the result.
+     *
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     *
+     * @see LLVM.LLVMConstAdd
+     */
     public fun add(
         v: IntValue,
         hasNUW: Boolean = false,
@@ -85,6 +112,17 @@ public class VectorValue internal constructor() : Value() {
         return VectorValue(ref)
     }
 
+    /**
+     * Subtract another value from this vector of integers
+     *
+     * If the sum has unsigned overflow, the result returned is the
+     * mathematical result modulo 2n, where n is the bit width of the result.
+     *
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     */
     public fun sub(
         v: IntValue,
         hasNUW: Boolean = false,
@@ -103,6 +141,17 @@ public class VectorValue internal constructor() : Value() {
         return VectorValue(ref)
     }
 
+    /**
+     * Multiply another value with this vector of integers
+     *
+     * If the sum has unsigned overflow, the result returned is the
+     * mathematical result modulo 2n, where n is the bit width of the result.
+     *
+     * NUW and NSW stand for "No Unsigned Wrap" and "No Signed Wrap",
+     * respectively. If [hasNUW] [hasNSW] are present, the result
+     * value of the add is a poison value if unsigned and/or signed overflow,
+     * respectively, occurs.
+     */
     public fun mul(
         v: IntValue,
         hasNUW: Boolean = false,

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.annotations.Shared
+import dev.supergrecko.kllvm.core.enumerations.TypeKind
 import dev.supergrecko.kllvm.core.typedefs.Value
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
@@ -31,4 +32,93 @@ public class VectorValue internal constructor() : Value() {
 
         return Value(value)
     }
+
+    //region Core::Values::Constants::ConstantExpressions
+    /**
+     * Negate all the values in the vector
+     *
+     * This operation is only valid on Vectors of Integers. Use FNeg for floats
+     *
+     * @see [LLVM.LLVMConstNeg]
+     */
+    public fun neg(
+        hasNUW: Boolean = false,
+        hasNSW: Boolean = false
+    ): VectorValue {
+        require(isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(!(hasNSW && hasNSW)) { "Cannot negate with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWNeg(ref)
+            hasNUW -> LLVM.LLVMConstNUWNeg(ref)
+            else -> LLVM.LLVMConstNeg(ref)
+        }
+
+        return VectorValue(ref)
+    }
+
+    public fun not(): VectorValue {
+        require(isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstNot(ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun add(
+        v: IntValue,
+        hasNUW: Boolean = false,
+        hasNSW: Boolean = false
+    ): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(!(hasNSW && hasNSW)) { "Cannot add with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWAdd(ref, v.ref)
+            hasNUW -> LLVM.LLVMConstNUWAdd(ref, v.ref)
+            else -> LLVM.LLVMConstAdd(ref, v.ref)
+        }
+
+        return VectorValue(ref)
+    }
+
+    public fun sub(
+        v: IntValue,
+        hasNUW: Boolean = false,
+        hasNSW: Boolean = false
+    ): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(!(hasNSW && hasNSW)) { "Cannot sub with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWSub(ref, v.ref)
+            hasNUW -> LLVM.LLVMConstNUWSub(ref, v.ref)
+            else -> LLVM.LLVMConstSub(ref, v.ref)
+        }
+
+        return VectorValue(ref)
+    }
+
+    public fun mul(
+        v: IntValue,
+        hasNUW: Boolean = false,
+        hasNSW: Boolean = false
+    ): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(!(hasNSW && hasNSW)) { "Cannot sub with both NSW and NUW" }
+
+        val ref = when (true) {
+            hasNSW -> LLVM.LLVMConstNSWMul(ref, v.ref)
+            hasNUW -> LLVM.LLVMConstNUWMul(ref, v.ref)
+            else -> LLVM.LLVMConstMul(ref, v.ref)
+        }
+
+        return VectorValue(ref)
+    }
+    //endregion Core::Values::Constants::ConstantExpressions
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -183,6 +183,8 @@ public class VectorValue internal constructor() : Value() {
      *
      * If the [exact] arg is present, the result value of the sdiv is a poison
      * value if the result would be rounded.
+     *
+     * TODO: Find a way to determine if type is unsigned
      */
     public fun sdiv(
         v: VectorValue,
@@ -209,6 +211,8 @@ public class VectorValue internal constructor() : Value() {
      *
      * If the [exact] arg is present, the result value of the udiv is a poison
      * value if %op1 is not a multiple of %op2, eg "((a udiv exact b) mul b) == a".
+     *
+     * TODO: Find a way to determine if type is unsigned
      */
     public fun udiv(
         v: VectorValue,

--- a/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/core/values/VectorValue.kt
@@ -1,8 +1,10 @@
 package dev.supergrecko.kllvm.core.values
 
 import dev.supergrecko.kllvm.annotations.Shared
+import dev.supergrecko.kllvm.core.enumerations.IntPredicate
 import dev.supergrecko.kllvm.core.enumerations.TypeKind
 import dev.supergrecko.kllvm.core.typedefs.Value
+import dev.supergrecko.kllvm.core.types.IntType
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
@@ -227,6 +229,118 @@ public class VectorValue internal constructor() : Value() {
         } else {
             LLVM.LLVMConstUDiv(ref, v.ref)
         }
+
+        return VectorValue(ref)
+    }
+
+    public fun rem(v: VectorValue, unsigned: Boolean): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = if (unsigned) {
+            LLVM.LLVMConstURem(ref, v.ref)
+        } else {
+            LLVM.LLVMConstSRem(ref, v.ref)
+        }
+
+        return VectorValue(ref)
+    }
+
+
+    public fun and(v: VectorValue): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstAnd(ref, v.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun or(v: VectorValue): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstOr(ref, v.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun xor(v: VectorValue): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstXor(ref, v.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun cmp(predicate: IntPredicate, v: VectorValue): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstICmp(predicate.value, ref, v.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun shl(v: VectorValue): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstShl(ref, v.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun lshr(v: VectorValue): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstLShr(ref, v.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun ashr(v: VectorValue): VectorValue {
+        require(isConstant() && v.isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+        require(v.getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstAShr(ref, v.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun trunc(type: IntType): VectorValue {
+        require(isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstTrunc(ref, type.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun sext(type: IntType): VectorValue {
+        require(isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstSExt(ref, type.ref)
+
+        return VectorValue(ref)
+    }
+
+    public fun zext(type: IntType): VectorValue {
+        require(isConstant())
+        require(getType().getTypeKind() == TypeKind.Integer)
+
+        val ref = LLVM.LLVMConstZExt(ref, type.ref)
 
         return VectorValue(ref)
     }

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/values/IntValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/values/IntValueTest.kt
@@ -1,0 +1,109 @@
+package dev.supergrecko.kllvm.core.values
+
+import dev.supergrecko.kllvm.core.types.IntType
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class IntValueTest {
+    @Test
+    fun `test negation of value`() {
+        val ty = IntType(32)
+        val v = IntValue(ty, 100L, true)
+
+        val neg = v.neg()
+
+        assertEquals(-100L, neg.getSignedValue())
+    }
+
+    @Test
+    fun `test inversion of value`() {
+        val ty = IntType(32)
+        val v = IntValue(ty, 100L, true)
+
+        val not = v.not()
+
+        assertEquals(-101, not.getSignedValue())
+    }
+
+    @Test
+    fun `test addition of values`() {
+        val ty = IntType(32)
+
+        val v1 = IntValue(ty, 100L, true)
+        val v2 = IntValue(ty, 300L, true)
+
+        val sum = v1.add(v2)
+
+        assertEquals(400, sum.getSignedValue())
+        assertEquals(400, sum.getUnsignedValue())
+    }
+
+    @Test
+    fun `test subtraction of values`() {
+        val ty = IntType(32)
+
+        val v1 = IntValue(ty, 400L, true)
+        val v2 = IntValue(ty, 200L, true)
+
+        val diff = v1.sub(v2)
+
+        assertEquals(200, diff.getSignedValue())
+        assertEquals(200, diff.getUnsignedValue())
+    }
+
+    @Test
+    fun `test multiplication of values`() {
+        val ty = IntType(32)
+
+        val v1 = IntValue(ty, 100L, true)
+        val v2 = IntValue(ty, 10L, true)
+
+        val product = v1.mul(v2)
+
+        assertEquals(1000, product.getSignedValue())
+        assertEquals(1000, product.getUnsignedValue())
+    }
+
+    @Test
+    fun `test unsigned division`() {
+        val ty = IntType(32)
+
+        val v1 = IntValue(ty, 100L, false)
+        val v2 = IntValue(ty, 10L, false)
+
+        val quotient1 = v1.udiv(v2, true)
+        val quotient2 = v1.udiv(v2, false)
+
+        assertEquals(10, quotient1.getSignedValue())
+        assertEquals(10, quotient2.getSignedValue())
+    }
+
+    @Test
+    fun `test signed division`() {
+        val ty = IntType(32)
+
+        val v1 = IntValue(ty, 100L, true)
+        val v2 = IntValue(ty, 10L, true)
+
+        val quotient1 = v1.udiv(v2, true)
+        val quotient2 = v1.udiv(v2, false)
+
+        assertEquals(10, quotient1.getSignedValue())
+        assertEquals(10, quotient2.getSignedValue())
+    }
+
+    @Test
+    fun `test fp division`() {
+        val ty = IntType(32)
+
+        // 10 div 3 is not an even number
+        val v1 = IntValue(ty, 10L, false)
+        val v2 = IntValue(ty, 3L, false)
+
+        val quotient1 = v1.udiv(v2, true)
+        val quotient2 = v1.udiv(v2, false)
+
+        assertEquals(3, quotient1.getSignedValue())
+        assertEquals(3, quotient2.getSignedValue())
+    }
+}

--- a/src/test/kotlin/dev/supergrecko/kllvm/core/values/IntValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/core/values/IntValueTest.kt
@@ -65,31 +65,21 @@ class IntValueTest {
     }
 
     @Test
-    fun `test unsigned division`() {
+    fun `test division`() {
         val ty = IntType(32)
 
         val v1 = IntValue(ty, 100L, false)
         val v2 = IntValue(ty, 10L, false)
 
-        val quotient1 = v1.udiv(v2, true)
-        val quotient2 = v1.udiv(v2, false)
+        val quotient1 = v1.div(v2, exact = true, unsigned = false)
+        val quotient2 = v1.div(v2, exact = false, unsigned = false)
+        val quotient3 = v1.div(v2, exact = true, unsigned = true)
+        val quotient4 = v1.div(v2, exact = false, unsigned = true)
 
         assertEquals(10, quotient1.getSignedValue())
         assertEquals(10, quotient2.getSignedValue())
-    }
-
-    @Test
-    fun `test signed division`() {
-        val ty = IntType(32)
-
-        val v1 = IntValue(ty, 100L, true)
-        val v2 = IntValue(ty, 10L, true)
-
-        val quotient1 = v1.udiv(v2, true)
-        val quotient2 = v1.udiv(v2, false)
-
-        assertEquals(10, quotient1.getSignedValue())
-        assertEquals(10, quotient2.getSignedValue())
+        assertEquals(10, quotient3.getSignedValue())
+        assertEquals(10, quotient4.getSignedValue())
     }
 
     @Test
@@ -100,10 +90,31 @@ class IntValueTest {
         val v1 = IntValue(ty, 10L, false)
         val v2 = IntValue(ty, 3L, false)
 
-        val quotient1 = v1.udiv(v2, true)
-        val quotient2 = v1.udiv(v2, false)
+        val quotient1 = v1.div(v2, exact = true, unsigned = false)
+        val quotient2 = v1.div(v2, exact = false, unsigned = false)
+        val quotient3 = v1.div(v2, exact = true, unsigned = true)
+        val quotient4 = v1.div(v2, exact = false, unsigned = true)
 
         assertEquals(3, quotient1.getSignedValue())
         assertEquals(3, quotient2.getSignedValue())
+        assertEquals(3, quotient3.getSignedValue())
+        assertEquals(3, quotient4.getSignedValue())
+    }
+
+    @Test
+    fun `test remainder`() {
+        val ty = IntType(32)
+
+        val v1 = IntValue(ty, 10L, false)
+        val v2 = IntValue(ty, 3L, false)
+
+        val rem1 = v1.rem(v2, true)
+        val rem2 = v1.rem(v2, false)
+
+        assertEquals(1, rem1.getUnsignedValue())
+        assertEquals(1, rem1.getSignedValue())
+
+        assertEquals(1, rem2.getUnsignedValue())
+        assertEquals(1, rem2.getSignedValue())
     }
 }


### PR DESCRIPTION
This implements most of the binary operations for Int values and Vector values as well as some for Float values.

**Unimplemented APIs**
- LLVMConstFRem
- LLVMConstFCmp
- LLVMConstGEP(2)
- LLVMConstInBoundsGEP(2)
- LLVMConstFPTrunc
- LLVMConstFPExt
- LLVMConstUIToFP
- LLVMConstSIToFP
- LLVMConstFPToSI
- LLVMConstFPToUI
- LLVMConstPtrToInt
- LLVMConstIntToPTr
- LLVMConstBitCast
- LLVMConstZExtOrBitCast
- LLVMConstSExtOrBitCast
- LLVMConstTruncOrBitCast
- LLVMConstPointerCast
- LLVMConstIntCast
- All APIs below here described at https://llvm.org/doxygen/group__LLVMCCoreValueConstantExpressions.html
