### PR TITLE
[api] Make Module ref public

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Module.kt
@@ -18,27 +18,19 @@ import org.bytedeco.llvm.global.LLVM
 import java.io.File
 import java.nio.ByteBuffer
 
-public class Module internal constructor() : AutoCloseable,
+public class Module public constructor(
+    public val ref: LLVMModuleRef
+) : AutoCloseable,
     Validatable, Disposable {
-    internal lateinit var ref: LLVMModuleRef
     public override var valid: Boolean = true
-
-    /**
-     * Construct a new Type from an LLVM pointer reference
-     */
-    public constructor(module: LLVMModuleRef) : this() {
-        ref = module
-    }
 
     public constructor(
         sourceFileName: String,
         context: Context = Context.getGlobalContext()
-    ) : this() {
-        ref = LLVM.LLVMModuleCreateWithNameInContext(
-            sourceFileName,
-            context.ref
-        )
-    }
+    ) : this(LLVM.LLVMModuleCreateWithNameInContext(
+        sourceFileName,
+        context.ref
+    ))
 
     //region Core::Modules
     /**


### PR DESCRIPTION
I updated my fork to the latest master and it broke several things. Most of those were fixable but one issue wasn't. I need Module.ref to pass to LLVMTargetMachineEmitToFile to generate an object file to link against.

In the process, I also removed the `lateinit` from ref while maintaining the exact same API (except the public ref of course, along with the no args internal constructor which wasn't being used anywhere).