### PR TITLE
[api] Add BasicBlock APIs and refactor property getters

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/internal/util/Conversions.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/internal/util/Conversions.kt
@@ -8,7 +8,7 @@ import org.bytedeco.javacpp.Pointer
  * Used because LLVM C api does not use booleans, it uses
  * C integers 1 and 0.
  */
-internal inline fun Int.fromLLVMBool() = this == 1
+internal fun Int.fromLLVMBool() = this == 1
 
 /**
  * Util function to convert kotlin [Boolean] to [Int]
@@ -16,7 +16,7 @@ internal inline fun Int.fromLLVMBool() = this == 1
  * Used because LLVM C api does not use booleans, it uses
  * C integers 1 and 0.
  */
-internal inline fun Boolean.toLLVMBool() = if (this) 1 else 0
+internal fun Boolean.toLLVMBool() = if (this) 1 else 0
 
 /**
  * Wrap a nullable LLVM ref into a new type or null.

--- a/src/main/kotlin/dev/supergrecko/kllvm/internal/util/Conversions.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/internal/util/Conversions.kt
@@ -1,12 +1,14 @@
 package dev.supergrecko.kllvm.internal.util
 
+import org.bytedeco.javacpp.Pointer
+
 /**
  * Util function to convert kotlin [Int] to [Boolean]
  *
  * Used because LLVM C api does not use booleans, it uses
  * C integers 1 and 0.
  */
-internal fun Int.fromLLVMBool() = this == 1
+internal inline fun Int.fromLLVMBool() = this == 1
 
 /**
  * Util function to convert kotlin [Boolean] to [Int]
@@ -14,4 +16,19 @@ internal fun Int.fromLLVMBool() = this == 1
  * Used because LLVM C api does not use booleans, it uses
  * C integers 1 and 0.
  */
-internal fun Boolean.toLLVMBool() = if (this) 1 else 0
+internal inline fun Boolean.toLLVMBool() = if (this) 1 else 0
+
+/**
+ * Wrap a nullable LLVM ref into a new type or null.
+ *
+ * A lot of the LLVM functions return nullable types to mimic C++'s nullptr.
+ *
+ * Instead of returning an if-expression this is used.
+ */
+internal inline fun <T : Pointer, R> wrap(item: T?, apply: (T) -> R): R? {
+    return if (item == null) {
+        null
+    } else {
+        apply(item)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/BasicBlock.kt
@@ -1,6 +1,10 @@
 package dev.supergrecko.kllvm.ir
 
+import dev.supergrecko.kllvm.internal.util.wrap
+import dev.supergrecko.kllvm.ir.instructions.Instruction
+import dev.supergrecko.kllvm.ir.values.FunctionValue
 import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef
+import org.bytedeco.llvm.global.LLVM
 
 public class BasicBlock internal constructor() {
     internal lateinit var ref: LLVMBasicBlockRef
@@ -11,4 +15,76 @@ public class BasicBlock internal constructor() {
     public constructor(block: LLVMBasicBlockRef) : this() {
         ref = block
     }
+
+    //region Core::BasicBlock
+    /**
+     * Converts this value into a Value
+     *
+     * This is done by unwrapping the instance into a Value
+     *
+     * TODO: Research more about this cast
+     *
+     * @see LLVM.LLVMBasicBlockAsValue
+     */
+    public fun toValue(): Value {
+        val v = LLVM.LLVMBasicBlockAsValue(ref)
+
+        return Value(v)
+    }
+
+    /**
+     * Get the name of the basic block
+     *
+     * @see LLVM.LLVMGetBasicBlockName
+     */
+    public fun getName(): String {
+        return LLVM.LLVMGetBasicBlockName(ref).string
+    }
+
+    /**
+     * Get the function this basic block resides in
+     *
+     * @see LLVM.LLVMGetBasicBlockParent
+     */
+    public fun getFunction(): FunctionValue {
+        val fn = LLVM.LLVMGetBasicBlockParent(ref)
+
+        return FunctionValue(fn)
+    }
+
+    /**
+     * Get the terminating instruction for this block, if it exists
+     *
+     * @see LLVM.LLVMGetBasicBlockTerminator
+     */
+    public fun getTerminator(): Instruction? {
+        val instr = LLVM.LLVMGetBasicBlockTerminator(ref)
+
+        return wrap(instr) { Instruction(it) }
+    }
+
+    /**
+     * Get the next block in the iterator
+     *
+     * Use with [BasicBlock.getNextBlock] and [BasicBlock.getPreviousBlock]
+     * to move the iterator
+     */
+    public fun getNextBlock(): BasicBlock? {
+        val bb = LLVM.LLVMGetNextBasicBlock(ref)
+
+        return wrap(bb) { BasicBlock(it) }
+    }
+
+    /**
+     * Get the previous block in the iterator
+     *
+     * Use with [BasicBlock.getNextBlock] and [BasicBlock.getPreviousBlock]
+     * to move the iterator
+     */
+    public fun getPreviousBlock(): BasicBlock? {
+        val bb = LLVM.LLVMGetPreviousBasicBlock(ref)
+
+        return wrap(bb) { BasicBlock(it) }
+    }
+    //endregion Core::BasicBlock
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Context.kt
@@ -36,32 +36,24 @@ public class Context public constructor() : AutoCloseable, Validatable,
 
     //region Core::Context
     /**
-     * Property determining whether the given context discards all value names.
+     * Does this context discard the IR names for values
      *
-     * If true, only the names of GlobalValue objects will be available in the IR.
-     * This can be used to save memory and runtime, especially in release mode.
-     *
-     * @throws IllegalArgumentException If internal instance has been dropped.
+     * @see LLVM.LLVMContextShouldDiscardValueNames
+     */
+    public fun isDiscardingValueNames(): Boolean {
+        require(valid)
+
+        return LLVM.LLVMContextShouldDiscardValueNames(ref).fromLLVMBool()
+    }
+
+    /**
+     * Set whether this module should discard value names
      *
      * @see LLVM.LLVMContextSetDiscardValueNames
      */
-    public var discardValueNames: Boolean
-        get() {
-            require(valid) { "This module has already been disposed." }
-
-            val willDiscard = LLVM.LLVMContextShouldDiscardValueNames(ref)
-
-            // Conversion from C++ bool to kotlin Boolean
-            return willDiscard.fromLLVMBool()
-        }
-        set(value) {
-            require(valid) { "This module has already been disposed." }
-
-            // Conversion from kotlin Boolean to C++ bool
-            val intValue = value.toLLVMBool()
-
-            LLVM.LLVMContextSetDiscardValueNames(ref, intValue)
-        }
+    public fun setDiscardValueNames(discard: Boolean) {
+        LLVM.LLVMContextSetDiscardValueNames(ref, discard.toLLVMBool())
+    }
 
     /**
      * Set the DiagnosticHandler for this context
@@ -70,7 +62,7 @@ public class Context public constructor() : AutoCloseable, Validatable,
      *
      * @see LLVM.LLVMContextSetDiagnosticHandler
      *
-     * TODO: Find out how to actually call this thing from Kotlin/Java
+     * TODO: Find out pointer type of [diagnosticContext]
      */
     public fun setDiagnosticHandler(
         handler: LLVMDiagnosticHandler,
@@ -88,7 +80,7 @@ public class Context public constructor() : AutoCloseable, Validatable,
      *
      * @see LLVM.LLVMContextSetDiagnosticHandler
      *
-     * TODO: Find out how to actually call this thing from Kotlin/Java
+     * TODO: Do something about Pointer() because right now it's just a nullptr
      */
     public fun setDiagnosticHandler(handler: LLVMDiagnosticHandler) {
         setDiagnosticHandler(handler, Pointer())

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Module.kt
@@ -3,6 +3,7 @@ package dev.supergrecko.kllvm.ir
 import dev.supergrecko.kllvm.internal.contracts.Disposable
 import dev.supergrecko.kllvm.internal.contracts.Validatable
 import dev.supergrecko.kllvm.internal.util.fromLLVMBool
+import dev.supergrecko.kllvm.internal.util.wrap
 import dev.supergrecko.kllvm.ir.types.FunctionType
 import dev.supergrecko.kllvm.ir.types.PointerType
 import dev.supergrecko.kllvm.ir.values.FunctionValue
@@ -71,42 +72,47 @@ public class Module internal constructor() : AutoCloseable,
     }
 
     /**
-     * A module identifier is a unique name for a module
+     * Get the name for this module
      *
      * @see LLVM.LLVMGetModuleIdentifier
-     * @see LLVM.LLVMSetModuleIdentifier
      */
-    public var moduleIdentifier: String
-        get() {
-            val ptr = LLVM.LLVMGetModuleIdentifier(ref, SizeTPointer(0))
+    public fun getModuleIdentifier(): String {
+        val ptr = LLVM.LLVMGetModuleIdentifier(ref, SizeTPointer(0))
 
-            return ptr.string
-        }
-        set(value) {
-            LLVM.LLVMSetModuleIdentifier(
-                ref,
-                value,
-                value.length.toLong()
-            )
-        }
+        return ptr.string
+    }
 
     /**
-     * Set the "source name" for this module
+     * Set the name for this module
+     *
+     * @see LLVM.LLVMSetModuleIdentifier
+     */
+    public fun setModuleIdentifier(id: String) {
+        LLVM.LLVMSetModuleIdentifier(ref, id, id.length.toLong())
+    }
+
+    /**
+     * Get the source name for this module
+     *
+     * LLVM can give "file names" for modules which show up while debugging
+     * and codegen.
      *
      * @see LLVM.LLVMGetSourceFileName
+     */
+    public fun getSourceFileName(): String {
+        val ptr = LLVM.LLVMGetSourceFileName(ref, SizeTPointer(0))
+
+        return ptr.string
+    }
+
+    /**
+     * Set the source name for this module
+     *
      * @see LLVM.LLVMSetSourceFileName
      */
-    public var sourceFileName: String
-        get() {
-            val ptr = LLVM.LLVMGetSourceFileName(ref, SizeTPointer(0))
-
-            return ptr.string
-        }
-        set(value) = LLVM.LLVMSetSourceFileName(
-            ref,
-            value,
-            value.length.toLong()
-        )
+    public fun setSourceFileName(name: String) {
+        LLVM.LLVMSetSourceFileName(ref, name, name.length.toLong())
+    }
 
     /**
      * Get a function in the module if it exists
@@ -115,9 +121,8 @@ public class Module internal constructor() : AutoCloseable,
      */
     public fun getFunction(name: String): FunctionValue? {
         val ref = LLVM.LLVMGetNamedFunction(ref, name)
-            ?: return null
 
-        return FunctionValue(ref)
+        return wrap(ref) { FunctionValue(it) }
     }
     //endregion Core::Modules
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Use.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Use.kt
@@ -15,7 +15,7 @@ public class Use internal constructor() {
 
     //region Core::Values::Usage
     /**
-     * Get the next usage in an iterator
+     * Get the next usage in the iterator
      *
      * This should be used with [Value.getFirstUse] as this continues the
      * underlying C++ iterator.

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
@@ -4,6 +4,7 @@ import dev.supergrecko.kllvm.internal.contracts.ContainsReference
 import dev.supergrecko.kllvm.internal.contracts.OrderedEnum
 import dev.supergrecko.kllvm.internal.contracts.Unreachable
 import dev.supergrecko.kllvm.internal.util.fromLLVMBool
+import dev.supergrecko.kllvm.internal.util.wrap
 import dev.supergrecko.kllvm.ir.instructions.Instruction
 import dev.supergrecko.kllvm.ir.values.FunctionValue
 import dev.supergrecko.kllvm.ir.values.GenericValue
@@ -70,35 +71,36 @@ public open class Value internal constructor() :
 
     //region Core::Values::GeneralAPIs
     /**
-     * Use the IR name for this value
+     * Get the IR name for this value
      *
      * @see LLVM.LLVMGetValueName2
-     * @see LLVM.LLVMSetValueName2
      */
-    public var valueName: String
-        get() {
-            val ptr = LLVM.LLVMGetValueName2(ref, SizeTPointer(0))
+    public fun getName(): String {
+        val ptr = LLVM.LLVMGetValueName2(ref, SizeTPointer(0))
 
-            return ptr.string
-        }
-        /**
-         * If this yields unexpected results, see the source code for this file
-         *
-         * LLVM-C does not provide a way for us to check if a value has a
-         * name or not and thus we cannot implement all the checks LLVM-C++
-         * does in their source file which means this may yield unwanted or
-         * unexpected results.
-         *
-         * https://llvm.org/doxygen/Value_8cpp_source.html#l00223
-         *
-         * TODO: Research if there is any other way we can determine the above
-         * TODO: Test when viable solution has been found
-         */
-        set(value) {
-            require(!(getContext().discardValueNames && this !is GlobalValue))
+        return ptr.string
+    }
 
-            LLVM.LLVMSetValueName2(ref, value, value.length.toLong())
-        }
+    /**
+     * Set the IR name for this value
+     *
+     * If this yields unexpected results, see the source code for this file
+     *
+     * LLVM-C does not provide a way for us to check if a value has a
+     * name or not and thus we cannot implement all the checks LLVM-C++
+     * does in their source file which means this may yield unwanted or
+     * unexpected results.
+     *
+     * https://llvm.org/doxygen/Value_8cpp_source.html#l00223
+     *
+     * TODO: Research if there is any other way we can determine the above
+     * TODO: Test when viable solution has been found
+     */
+    public fun setName(name: String) {
+        require(!(getContext().discardValueNames && this !is GlobalValue))
+
+        LLVM.LLVMSetValueName2(ref, name, name.length.toLong())
+    }
 
     /**
      * Get the type of this value
@@ -209,11 +211,7 @@ public open class Value internal constructor() :
     public fun getFirstUse(): Use? {
         val use = LLVM.LLVMGetFirstUse(ref)
 
-        return if (use != null) {
-            Use(use)
-        } else {
-            null
-        }
+        return wrap(use) { Use(it) }
     }
     //endregion Core::Values::Usage
 
@@ -257,6 +255,8 @@ public open class Value internal constructor() :
     //region Typecasting
     /**
      * Attempts to use the current [ref] for a new value
+     *
+     * TODO: Do something about these
      */
     public fun asArrayValue() = ConstantArray(ref)
     public fun asFloatValue() = ConstantFloat(ref)

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
@@ -97,7 +97,7 @@ public open class Value internal constructor() :
      * TODO: Test when viable solution has been found
      */
     public fun setName(name: String) {
-        require(!(getContext().discardValueNames && this !is GlobalValue))
+        require(!(getContext().isDiscardingValueNames() && this !is GlobalValue))
 
         LLVM.LLVMSetValueName2(ref, name, name.length.toLong())
     }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
@@ -228,6 +228,32 @@ public open class Value internal constructor() :
     }
     //endregion Core::Values::Constants
 
+    //region Core::BasicBlock
+    /**
+     * Is this value a basic block?
+     *
+     * @see LLVM.LLVMIsABasicBlock
+     */
+    public fun isBasicBlock(): Boolean {
+        return LLVM.LLVMIsABasicBlock(ref) != null
+    }
+
+    /**
+     * Converts this value into a Basic Block
+     *
+     * This is done by unwrapping the instance into a BasicBlock
+     *
+     * TODO: Research more about this cast
+     *
+     * @see LLVM.LLVMValueAsBasicBlock
+     */
+    public fun toBasicBlock(): BasicBlock {
+        val bb = LLVM.LLVMValueAsBasicBlock(ref)
+
+        return BasicBlock(bb)
+    }
+    //endregion Core::BasicBlock
+
     //region Typecasting
     /**
      * Attempts to use the current [ref] for a new value

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/FunctionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/FunctionValue.kt
@@ -160,26 +160,15 @@ public open class FunctionValue internal constructor() : Value() {
     //endregion Core::Values::Constants::FunctionValues::FunctionParameters
 
     //region Core::Values::Constants::FunctionValues::IndirectFunctions
-    /**
-     * @see LLVM.LLVMGetGlobalIFuncResolver
-     * @see LLVM.LLVMSetGlobalIFuncResolver
-     */
-    public var indirectFunctionResolver: IndirectFunction
-        get() {
-            val resolver = LLVM.LLVMGetGlobalIFuncResolver(ref)
+    public fun getIndirectResolver(): IndirectFunction? {
+        val resolver = LLVM.LLVMGetGlobalIFuncResolver(ref)
 
-            return if (resolver == null) {
-                throw RuntimeException(
-                    "This function does not have an " +
-                            "indirect resolver"
-                )
-            } else {
-                IndirectFunction(resolver)
-            }
-        }
-        set(value) {
-            LLVM.LLVMSetGlobalIFuncResolver(ref, value.ref)
-        }
+        return wrap(resolver) { IndirectFunction(it) }
+    }
+
+    public fun setIndirectResolver(function: IndirectFunction) {
+        LLVM.LLVMSetGlobalIFuncResolver(ref, function.ref)
+    }
 
     /**
      * Make this indirect function global in the given [module]
@@ -207,51 +196,39 @@ public open class FunctionValue internal constructor() : Value() {
     //endregion Core::Values::Constants::FunctionValues::IndirectFunctions
 
     //region Core::Values::Constants::FunctionValues
-    /**
-     * Set the call convention for this function
-     *
-     * @see LLVM.LLVMGetFunctionCallConv
-     * @see LLVM.LLVMSetFunctionCallConv
-     */
-    public var callConvention: CallConvention
-        get() {
-            val cc = LLVM.LLVMGetFunctionCallConv(ref)
+    public fun getCallConvention(): CallConvention {
+        val cc = LLVM.LLVMGetFunctionCallConv(ref)
 
-            return CallConvention.values()
-                .firstOrNull { it.value == cc }
-                ?: throw Unreachable()
-        }
-        set(value) {
-            LLVM.LLVMSetFunctionCallConv(ref, value.value)
-        }
+        return CallConvention.values()
+            .firstOrNull { it.value == cc }
+            ?: throw Unreachable()
+    }
 
-    /**
-     * Set the personality function for this function
-     *
-     * @see LLVM.LLVMGetPersonalityFn
-     * @see LLVM.LLVMSetPersonalityFn
-     */
-    public var personalityFunction: FunctionValue
-        get() {
-            require(hasPersonalityFunction())
+    public fun setCallConvention(convention: CallConvention) {
+        LLVM.LLVMSetFunctionCallConv(ref, convention.value)
+    }
 
-            val fn = LLVM.LLVMGetPersonalityFn(ref)
-
-            return FunctionValue(fn)
-        }
-        set(value) {
-            LLVM.LLVMSetPersonalityFn(ref, value.ref)
+    public fun getPersonalityFunction(): FunctionValue {
+        require(hasPersonalityFunction()) {
+            "This function does not have a personality function"
         }
 
-    /**
-     * Set the garbage collector name for this function
-     *
-     * @see LLVM.LLVMGetGC
-     * @see LLVM.LLVMSetGC
-     */
-    public var garbageCollector: String
-        get() = LLVM.LLVMGetGC(ref).string
-        set(value) = LLVM.LLVMSetGC(ref, value)
+        val fn = LLVM.LLVMGetPersonalityFn(ref)
+
+        return FunctionValue(fn)
+    }
+
+    public fun setPersonalityFunction(function: FunctionValue) {
+        LLVM.LLVMSetPersonalityFn(ref, function.ref)
+    }
+
+    public fun getGarbageCollector(): String {
+        return LLVM.LLVMGetGC(ref).string
+    }
+
+    public fun setGarbageCollector(collector: String) {
+        LLVM.LLVMSetGC(ref, collector)
+    }
 
     /**
      * Determine if this function has a personality function

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalAlias.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalAlias.kt
@@ -13,16 +13,22 @@ public class GlobalAlias internal constructor(): GlobalValue() {
     }
 
     /**
-     * Manage the value this alias is an alias for
+     * Get the value this alias is an alias for
      *
      * @see LLVM.LLVMAliasGetAliasee
+     */
+    public fun getAliasOf(): Value {
+        val value = LLVM.LLVMAliasGetAliasee(ref)
+
+        return Value(value)
+    }
+
+    /**
+     * Set the value this aliases
+     *
      * @see LLVM.LLVMAliasSetAliasee
      */
-    public var aliasOf: Value
-        get() {
-            val value = LLVM.LLVMAliasGetAliasee(ref)
-
-            return Value(value)
-        }
-        set(value) = LLVM.LLVMAliasSetAliasee(ref, value.ref)
+    public fun setAliasOf(value: Value) {
+        LLVM.LLVMAliasSetAliasee(ref, value.ref)
+    }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalValue.kt
@@ -47,49 +47,53 @@ public open class GlobalValue internal constructor(): Value(), ConstantValue {
     }
 
     //region Core::Values::Constants::GlobalValues
-    public var linkage: Linkage
-        get() {
-            val refLinkage = LLVM.LLVMGetLinkage(ref)
+    public fun getLinkage(): Linkage {
+        val ln = LLVM.LLVMGetLinkage(ref)
 
-            return Linkage.values()
-                .firstOrNull { it.value == refLinkage }
-                ?: throw Unreachable()
-        }
-        set(value) = LLVM.LLVMSetLinkage(ref, value.value)
+        return Linkage.values().first { it.value == ln }
+    }
 
-    public var section: String
-        get() = LLVM.LLVMGetSection(ref).string
-        set(value) = LLVM.LLVMSetSection(ref, value)
+    public fun setLinkage(linkage: Linkage) {
+       LLVM.LLVMSetLinkage(ref, linkage.value)
+    }
 
-    public var visibility: Visibility
-        get() {
-            val refVisibility = LLVM.LLVMGetVisibility(ref)
+    public fun getSection(): String {
+        return LLVM.LLVMGetSection(ref).string
+    }
 
-            return Visibility.values()
-                .firstOrNull { it.value == refVisibility }
-                ?: throw Unreachable()
-        }
-    set(value) = LLVM.LLVMSetVisibility(ref, value.value)
+    public fun setSection(data: String) {
+        LLVM.LLVMSetSection(ref, data)
+    }
 
-    public var dllStorageClass: DLLStorageClass
-        get() {
-            val refStorageClass = LLVM.LLVMGetDLLStorageClass(ref)
+    public fun getVisibility(): Visibility {
+        val visibility = LLVM.LLVMGetVisibility(ref)
 
-            return DLLStorageClass.values()
-                .firstOrNull { it.value == refStorageClass }
-                ?: throw Unreachable()
-        }
-        set(value) = LLVM.LLVMSetDLLStorageClass(ref, value.value)
+        return Visibility.values().first { it.value == visibility }
+    }
 
-    public var unnamedAddress: UnnamedAddress
-        get() {
-            val refUnnamedAddress = LLVM.LLVMGetUnnamedAddress(ref)
+    public fun setVisibility(visibility: Visibility) {
+        LLVM.LLVMSetVisibility(ref, visibility.value)
+    }
 
-            return UnnamedAddress.values()
-                .firstOrNull { it.value == refUnnamedAddress }
-                ?: throw Unreachable()
-        }
-        set(value) = LLVM.LLVMSetUnnamedAddress(ref, value.value)
+    public fun getStorageClass(): DLLStorageClass {
+        val storage = LLVM.LLVMGetDLLStorageClass(ref)
+
+        return DLLStorageClass.values().first { it.value == storage }
+    }
+
+    public fun setStorageClass(storageClass: DLLStorageClass) {
+        LLVM.LLVMSetDLLStorageClass(ref, storageClass.value)
+    }
+
+    public fun getUnnamedAddress(): UnnamedAddress {
+        val addr = LLVM.LLVMGetUnnamedAddress(ref)
+
+        return UnnamedAddress.values().first { it.value == addr }
+    }
+
+    public fun setUnnamedAddress(address: UnnamedAddress) {
+        LLVM.LLVMSetUnnamedAddress(ref, address.value)
+    }
 
     /**
      * Determine if this is just a signature for something

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariable.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariable.kt
@@ -77,13 +77,12 @@ public class GlobalVariable internal constructor() : Value() {
     /**
      * Get the thread local mode for this variable
      *
+     * This does not need to test for [isThreadLocal] as it will return
+     * [ThreadLocalMode.NotThreadLocal] if it is not thread local.
+     *
      * @see LLVM.LLVMGetThreadLocalMode
      */
     public fun getThreadLocalMode(): ThreadLocalMode {
-        if (!isThreadLocal()) {
-            throw IllegalArgumentException("This variable is not thread local.")
-        }
-
         val tlm = LLVM.LLVMGetThreadLocalMode(ref)
 
         return ThreadLocalMode.values().first { it.value == tlm }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariable.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariable.kt
@@ -1,13 +1,13 @@
 package dev.supergrecko.kllvm.ir.values
 
-import dev.supergrecko.kllvm.internal.contracts.Unreachable
 import dev.supergrecko.kllvm.internal.util.fromLLVMBool
 import dev.supergrecko.kllvm.internal.util.toLLVMBool
+import dev.supergrecko.kllvm.internal.util.wrap
 import dev.supergrecko.kllvm.ir.ThreadLocalMode
 import dev.supergrecko.kllvm.ir.Value
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
-import java.lang.RuntimeException
+import java.lang.IllegalArgumentException
 
 public class GlobalVariable internal constructor() : Value() {
     /**
@@ -19,67 +19,101 @@ public class GlobalVariable internal constructor() : Value() {
 
     //region Core::Values::Constants::GlobalVariables
     /**
-     * Use whether this value is externally initialized or not
+     * Is this variable initialized outside of this module?
      *
      * @see LLVM.LLVMIsExternallyInitialized
+     */
+    public fun isExternallyInitialized(): Boolean {
+        return LLVM.LLVMIsExternallyInitialized(ref).fromLLVMBool()
+    }
+
+    /**
+     * Set whether this value is externally initialized or not
+     *
      * @see LLVM.LLVMSetExternallyInitialized
      */
-    public var externallyInitialized: Boolean
-        get() = LLVM.LLVMIsExternallyInitialized(ref).fromLLVMBool()
-        set(value) = LLVM.LLVMSetExternallyInitialized(ref, value.toLLVMBool())
+    public fun setExternallyInitialized(isExternal: Boolean) {
+        LLVM.LLVMSetExternallyInitialized(ref, isExternal.toLLVMBool())
+    }
 
     /**
-     * Use the initializer value for this value
+     * Get the initializer for this value if it exists
      *
      * @see LLVM.LLVMGetInitializer
+     */
+    public fun getInitializer(): Value? {
+        val value = LLVM.LLVMGetInitializer(ref)
+
+        return wrap(value) { Value(it) }
+    }
+
+    /**
+     * Set the initializer value for this variable
+     *
      * @see LLVM.LLVMSetInitializer
      */
-    public var initializer: Value
-        get() {
-            val v = LLVM.LLVMGetInitializer(ref)
-
-            return if (v == null) {
-                throw RuntimeException("$this does not have an initializer")
-            } else {
-                Value(v)
-            }
-        }
-        set(value) = LLVM.LLVMSetInitializer(ref, value.ref)
+    public fun setInitializer(value: Value) {
+        LLVM.LLVMSetInitializer(ref, value.ref)
+    }
 
     /**
-     * Determine whether this value should be global or not
+     * Is this variable a global constant?
      *
      * @see LLVM.LLVMIsGlobalConstant
+     */
+    public fun isGlobalConstant(): Boolean {
+        return LLVM.LLVMIsGlobalConstant(ref).fromLLVMBool()
+    }
+
+    /**
+     * Set whether this value is a global constant or not
+     *
      * @see LLVM.LLVMSetGlobalConstant
      */
-    public var globalConstant: Boolean
-        get() = LLVM.LLVMIsGlobalConstant(ref).fromLLVMBool()
-        set(value) = LLVM.LLVMSetGlobalConstant(ref, value.toLLVMBool())
+    public fun setGlobalConstant(isGlobalConstant: Boolean) {
+        LLVM.LLVMSetGlobalConstant(ref, isGlobalConstant.toLLVMBool())
+    }
 
     /**
-     * Use the thread local mode for this value
+     * Get the thread local mode for this variable
      *
-     * @see LLVM.LLVMSetThreadLocalMode
      * @see LLVM.LLVMGetThreadLocalMode
      */
-    public var threadLocalMode: ThreadLocalMode
-        get() {
-            val mode = LLVM.LLVMGetThreadLocalMode(ref)
-
-            return ThreadLocalMode.values()
-                .firstOrNull { it.value == mode }
-                ?: throw Unreachable()
+    public fun getThreadLocalMode(): ThreadLocalMode {
+        if (!isThreadLocal()) {
+            throw IllegalArgumentException("This variable is not thread local.")
         }
-        set(value) = LLVM.LLVMSetThreadLocalMode(ref, value.value)
+
+        val tlm = LLVM.LLVMGetThreadLocalMode(ref)
+
+        return ThreadLocalMode.values().first { it.value == tlm }
+    }
 
     /**
-     * Use whether this value is thread local
+     * Set the [threadLocality] of this variable
      *
-     * @see LLVM.LLVMSetThreadLocal
+     * @see LLVM.LLVMSetThreadLocalMode
+     */
+    public fun setThreadLocalMode(threadLocality: ThreadLocalMode) {
+        LLVM.LLVMSetThreadLocalMode(ref, threadLocality.value)
+    }
+
+    /**
+     * Is this variable thread local?
+     *
      * @see LLVM.LLVMIsThreadLocal
      */
-    public var threadLocal: Boolean
-        get() = LLVM.LLVMIsThreadLocal(ref).fromLLVMBool()
-        set(value) = LLVM.LLVMSetThreadLocal(ref, value.toLLVMBool())
+    public fun isThreadLocal(): Boolean {
+        return LLVM.LLVMIsThreadLocal(ref).fromLLVMBool()
+    }
+
+    /**
+     * Set whether this variable is thread local or not
+     *
+     * @see LLVM.LLVMSetThreadLocal
+     */
+    public fun setThreadLocal(isThreadLocal: Boolean) {
+        LLVM.LLVMSetThreadLocal(ref, isThreadLocal.toLLVMBool())
+    }
     //endregion Core::Values::Constants::GlobalVariables
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/BuilderTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/BuilderTest.kt
@@ -31,7 +31,8 @@ class BuilderTest {
         // A simple comparison won't do because even though the
         // underlying reference is the same, the Builder object
         // that holds the reference is different
-        // TODO?: Implement equals/hashCode for Builder by comparing underlying refs?
+        // TODO?: Implement equals/hashCode for Builder by comparing underlying
+        //   refs?
         assertEquals(builder.getInsertBlock()?.ref, basicBlock.ref)
 
         builder.clearInsertPosition()

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/BuilderTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/BuilderTest.kt
@@ -25,7 +25,7 @@ class BuilderTest {
             )
         )
 
-        val basicBlock = function.appendBasicBlock("entry")
+        val basicBlock = function.addBlock("entry")
         builder.positionAtEnd(basicBlock)
 
         // A simple comparison won't do because even though the
@@ -96,7 +96,7 @@ class BuilderTest {
             )
         )
 
-        val basicBlock = caller.appendBasicBlock("entry")
+        val basicBlock = caller.addBlock("entry")
         builder.positionAtEnd(basicBlock)
 
         if (externFunc !is Value) {

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/ContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/ContextTest.kt
@@ -54,8 +54,8 @@ class ContextTest {
         val ctx = Context()
 
         runAll(true, false) { it, _ ->
-            ctx.discardValueNames = it
-            assertEquals(it, ctx.discardValueNames)
+            ctx.setDiscardValueNames(it)
+            assertEquals(it, ctx.isDiscardingValueNames())
         }
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/ModuleTest.kt
@@ -14,22 +14,24 @@ import org.junit.jupiter.api.Test
 class ModuleTest {
     @Test
     fun `setting a module identifier`() {
-        val mod = Module("test.ll")
-        mod.moduleIdentifier = "test"
+        val mod = Module("test.ll").apply {
+            setModuleIdentifier("test")
+        }
 
-        assertEquals("test", mod.moduleIdentifier)
+        assertEquals("test", mod.getModuleIdentifier())
 
         mod.dispose()
     }
 
     @Test
     fun `cloning a module with a module identifier`() {
-        val mod = Module("test.ll")
-        mod.moduleIdentifier = "test"
+        val mod = Module("test.ll").apply {
+            setModuleIdentifier("test")
+        }
 
         val clone = mod.clone()
 
-        assertEquals(mod.moduleIdentifier, clone.moduleIdentifier)
+        assertEquals(mod.getModuleIdentifier(), clone.getModuleIdentifier())
 
         mod.dispose()
         clone.dispose()
@@ -39,11 +41,11 @@ class ModuleTest {
     fun `modifying the module source name`() {
         val mod = Module("test.ll")
 
-        assertEquals("test.ll", mod.sourceFileName)
+        assertEquals("test.ll", mod.getSourceFileName())
 
-        mod.sourceFileName = "test2.ll"
+        mod.setSourceFileName("test2.ll")
 
-        assertEquals("test2.ll", mod.sourceFileName)
+        assertEquals("test2.ll", mod.getSourceFileName())
 
         mod.dispose()
     }
@@ -92,7 +94,6 @@ class ModuleTest {
     @Test
     fun `writing module to byte code by file path`() {
         val file = File("./out.bc")
-
         val module = Module("test.ll")
 
         module.toFile(file.absolutePath)
@@ -111,7 +112,7 @@ class ModuleTest {
         val buf = module.toMemoryBuffer()
         val mod = buf.parse(context)
 
-        assertEquals("test.ll", mod.sourceFileName)
+        assertEquals("test.ll", mod.getSourceFileName())
 
         module.dispose()
         context.dispose()
@@ -126,7 +127,7 @@ class ModuleTest {
 
         val mod = buf.getModule(context)
 
-        assertEquals("test.ll", mod.sourceFileName)
+        assertEquals("test.ll", mod.getSourceFileName())
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalAliasTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalAliasTest.kt
@@ -11,20 +11,22 @@ class GlobalAliasTest {
     @Test
     fun `aliases track the value`() {
         val mod = Module("test.ll")
-
         val ty = IntType(32)
         val v = ConstantInt(ty, 32L, true)
-        val global = mod.addGlobal("value_1", ty)
-        global.initializer = v
+
+        val global = mod.addGlobal("value_1", ty).apply {
+            setInitializer(v)
+        }
 
         val alias = mod.addAlias(ty.toPointerType(), global, "value_2")
-
-        val aliasValue = alias.aliasOf
+        val aliasValue = alias.getAliasOf()
 
         assertEquals(
             aliasValue.asIntValue().getSignedValue(),
             global.asIntValue().getSignedValue()
         )
+
+        mod.dispose()
     }
 
     @Test
@@ -34,6 +36,8 @@ class GlobalAliasTest {
         val alias = mod.getAlias("unknown_alias")
 
         assertNull(alias)
+
+        mod.dispose()
     }
 
     @Test
@@ -41,9 +45,12 @@ class GlobalAliasTest {
         val mod = Module("test.ll")
         val ty = IntType(32).toPointerType()
         val global = mod.addGlobal("value_1", ty)
+
         val alias = mod.addAlias(ty, global, "alias_1")
         val aliasOf = mod.getAlias("alias_1")
 
         assertEquals(alias.ref, aliasOf?.ref)
+
+        mod.dispose()
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalValueTest.kt
@@ -8,14 +8,15 @@ import kotlin.test.assertEquals
 class GlobalValueTest {
     @Test
     fun `fetching module`() {
-        val module = Module("test.ll")
-        module.moduleIdentifier = "basic"
+        val module = Module("test.ll").apply {
+            setModuleIdentifier("basic")
+        }
 
         val global = module.addGlobal("my_int", IntType(32))
         val globalModule = global.asGlobalValue().getModule()
 
         assertEquals(
-            module.moduleIdentifier, globalModule.moduleIdentifier
+            module.getModuleIdentifier(), globalModule.getModuleIdentifier()
         )
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariableTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariableTest.kt
@@ -1,43 +1,59 @@
 package dev.supergrecko.kllvm.ir.values
 
-import dev.supergrecko.kllvm.test.runAll
 import dev.supergrecko.kllvm.ir.Module
 import dev.supergrecko.kllvm.ir.ThreadLocalMode
 import dev.supergrecko.kllvm.ir.types.IntType
 import dev.supergrecko.kllvm.ir.values.constants.ConstantInt
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import dev.supergrecko.kllvm.test.runAll
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class GlobalVariableTest {
     @Test
     fun `creating a global value`() {
         val ty = IntType(32)
-        val value = Module("test.ll").addGlobal("v", ty)
-
         val v = ConstantInt(ty, 100L, true)
-        value.initializer = v
 
-        assertFalse { value.globalConstant }
-        assertFalse { value.threadLocal }
-        assertFalse { value.externallyInitialized }
+        val mod = Module("test.ll")
+        val value = mod.addGlobal("v", ty).apply {
+            setInitializer(v)
+        }
 
-        assertEquals(100L, value.initializer.asIntValue().getSignedValue())
-        assertEquals("v", value.valueName)
-        assertEquals(ThreadLocalMode.NotThreadLocal, value.threadLocalMode)
+        with(value) {
+            assertFalse { isGlobalConstant() }
+            assertFalse { isThreadLocal() }
+            assertFalse { isExternallyInitialized() }
+
+            val initializer = value.getInitializer()
+                ?.asIntValue()
+                ?.getSignedValue()
+
+            assertEquals(100L, initializer)
+            assertEquals("v", getName())
+            assertEquals(ThreadLocalMode.NotThreadLocal, getThreadLocalMode())
+        }
+
+        mod.dispose()
     }
 
     @Test
     fun `set global constant`() {
         val ty = IntType(32)
-        val value = Module("test.ll").addGlobal("v", ty)
+        val v = ConstantInt(IntType(32), 100L, true)
+        val mod = Module("test.ll")
 
-        value.initializer = ConstantInt(IntType(32), 100L, true)
-        value.globalConstant = true
+        val value = mod.addGlobal("v", ty).apply {
+            setInitializer(v)
+            setGlobalConstant(true)
+        }
 
-        assertTrue { value.globalConstant }
+        assertTrue { value.isGlobalConstant() }
+
+        mod.dispose()
     }
 
     @Test
@@ -45,23 +61,26 @@ class GlobalVariableTest {
         val module = Module("test.ll")
         val v = module.addGlobal("v", IntType(32), 0x03f7d)
 
-        assertFailsWith<RuntimeException> {
-            v.initializer
-        }
+        assertNull(v.getInitializer())
+
+        module.dispose()
     }
 
     @Test
     fun `thread localization properties works as expected`() {
         val ty = IntType(32)
-        val value = Module("test.ll").addGlobal("v", ty)
-
-        value.threadLocal = true
+        val mod = Module("test.ll")
+        val value = mod.addGlobal("v", ty).apply {
+            setThreadLocal(true)
+        }
 
         // While this may seem redundant it is not, see impl for the getter
         runAll(*ThreadLocalMode.values()) { it, _ ->
-            value.threadLocalMode = it
+            value.setThreadLocalMode(it)
 
-            assertEquals(it, value.threadLocalMode)
+            assertEquals(it, value.getThreadLocalMode())
         }
+
+        mod.dispose()
     }
 }

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/values/constants/ConstantIntTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/values/constants/ConstantIntTest.kt
@@ -43,8 +43,7 @@ class ConstantIntTest {
 
     @Test
     fun `addition of values`() {
-        val ty =
-            IntType(32)
+        val ty = IntType(32)
 
         val v1 = ConstantInt(ty, 100)
         val v2 = ConstantInt(ty, 300)


### PR DESCRIPTION
The public var setters/getters for certain classes lead to inconsistent naming and they provide more problems than features they provide (unable to use primitives, weird naming)

This adds some of the basic APIs for BasicBlock and replaces these old getters