### PR TITLE
Experiment: Try using ArrowKt with Optional instead of nullable types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,19 +6,19 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {
-        name "jitpack.io"
-        url "https://jitpack.io"
-    }
-    maven {
-        name "jcenter"
-        url "https://jcenter.bintray.com"
-    }
+    jcenter()
+
+    maven { url "https://jitpack.io" }
+    maven { url "https://jcenter.bintray.com" }
+    maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
 }
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.70"
     compile "org.bytedeco:llvm-platform:9.0.0-1.5.2"
+    compile "io.arrow-kt:arrow-core:0.10.4"
+    compile "io.arrow-kt:arrow-syntax:0.10.4"
+    compile "io.arrow-kt:arrow-meta:0.10.4"
 
     testCompile "org.jetbrains.kotlin:kotlin-test:1.3.70"
     testCompile "org.junit.jupiter:junit-jupiter-engine:5.2.0"
@@ -49,12 +49,11 @@ test {
 
     afterSuite { descriptor, result ->
         if (!descriptor.parent) {
-            println()
             logger.quiet "[TESTS] [${result.resultType}] (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
         }
     }
 }
 
-task("cp") {
+task "cp" {
     println sourceSets.main.compileClasspath.asPath
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/internal/contracts/OrderedEnum.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/internal/contracts/OrderedEnum.kt
@@ -9,6 +9,6 @@ package dev.supergrecko.kllvm.internal.contracts
  * Multiple of the enums from LLVM have modified ordinals which is why we need
  * to do this.
  */
-public interface OrderedEnum<T> {
+public interface OrderedEnum<T : Number> {
     public val value: T
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/internal/util/Conversions.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/internal/util/Conversions.kt
@@ -1,5 +1,8 @@
 package dev.supergrecko.kllvm.internal.util
 
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
 import org.bytedeco.javacpp.Pointer
 
 /**
@@ -19,16 +22,19 @@ internal fun Int.fromLLVMBool() = this == 1
 internal fun Boolean.toLLVMBool() = if (this) 1 else 0
 
 /**
- * Wrap a nullable LLVM ref into a new type or null.
+ * Wrap a nullable LLVM ref into an option of said type.
  *
  * A lot of the LLVM functions return nullable types to mimic C++'s nullptr.
  *
  * Instead of returning an if-expression this is used.
  */
-internal inline fun <T : Pointer, R> wrap(item: T?, apply: (T) -> R): R? {
+internal inline fun <T : Pointer, R> wrap(
+    item: T?,
+    apply: (T) -> R
+): Option<R> {
     return if (item == null) {
-        null
+        None
     } else {
-        apply(item)
+        Some(apply(item))
     }
 }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/BasicBlock.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.ir
 
+import arrow.core.Option
 import dev.supergrecko.kllvm.internal.util.wrap
 import dev.supergrecko.kllvm.ir.instructions.Instruction
 import dev.supergrecko.kllvm.ir.values.FunctionValue
@@ -57,7 +58,7 @@ public class BasicBlock internal constructor() {
      *
      * @see LLVM.LLVMGetBasicBlockTerminator
      */
-    public fun getTerminator(): Instruction? {
+    public fun getTerminator(): Option<Instruction> {
         val instr = LLVM.LLVMGetBasicBlockTerminator(ref)
 
         return wrap(instr) { Instruction(it) }
@@ -69,7 +70,7 @@ public class BasicBlock internal constructor() {
      * Use with [BasicBlock.getNextBlock] and [BasicBlock.getPreviousBlock]
      * to move the iterator
      */
-    public fun getNextBlock(): BasicBlock? {
+    public fun getNextBlock(): Option<BasicBlock> {
         val bb = LLVM.LLVMGetNextBasicBlock(ref)
 
         return wrap(bb) { BasicBlock(it) }
@@ -81,7 +82,7 @@ public class BasicBlock internal constructor() {
      * Use with [BasicBlock.getNextBlock] and [BasicBlock.getPreviousBlock]
      * to move the iterator
      */
-    public fun getPreviousBlock(): BasicBlock? {
+    public fun getPreviousBlock(): Option<BasicBlock> {
         val bb = LLVM.LLVMGetPreviousBasicBlock(ref)
 
         return wrap(bb) { BasicBlock(it) }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Builder.kt
@@ -1,7 +1,9 @@
 package dev.supergrecko.kllvm.ir
 
+import arrow.core.Option
 import dev.supergrecko.kllvm.internal.contracts.Disposable
 import dev.supergrecko.kllvm.internal.contracts.Validatable
+import dev.supergrecko.kllvm.internal.util.wrap
 import dev.supergrecko.kllvm.ir.instructions.Instruction
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMBuilderRef
@@ -33,7 +35,7 @@ public class Builder public constructor(
     }
 
     /**
-     * LLVMPositionBuilder
+     * @see LLVM.LLVMPositionBuilder
      */
     public fun positionBefore(instruction: Instruction) {
         // TODO: Test
@@ -41,29 +43,30 @@ public class Builder public constructor(
     }
 
     /**
-     * LLVMPositionBuilderAtEnd
+     * @see LLVM.LLVMPositionBuilderAtEnd
      */
     public fun positionAtEnd(basicBlock: BasicBlock) {
         LLVM.LLVMPositionBuilderAtEnd(ref, basicBlock.ref)
     }
 
     /**
-     * LLVMGetInsertBlock
+     * @see LLVM.LLVMGetInsertBlock
      */
-    public fun getInsertBlock(): BasicBlock? {
-        val ref = LLVM.LLVMGetInsertBlock(ref) ?: return null
-        return BasicBlock(ref)
+    public fun getInsertBlock(): Option<BasicBlock> {
+        val ref = LLVM.LLVMGetInsertBlock(ref)
+
+        return wrap(ref) { BasicBlock(it) }
     }
 
     /**
-     * LLVMClearInsertionPosition
+     * @see LLVM.LLVMClearInsertionPosition
      */
     public fun clearInsertPosition() {
         LLVM.LLVMClearInsertionPosition(ref)
     }
 
     /**
-     * LLVMInsertIntoBuilderWithName
+     * @see LLVM.LLVMInsertIntoBuilderWithName
      */
     public fun insert(instruction: Instruction, name: String?) {
         // TODO: Test
@@ -98,9 +101,7 @@ public class Builder public constructor(
             // string
             resultName ?: ""
         )
-        return Instruction(
-            ref
-        )
+        return Instruction(ref)
     }
 
     public fun buildRet(value: Value): Instruction {

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Module.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.ir
 
+import arrow.core.Option
 import dev.supergrecko.kllvm.internal.contracts.Disposable
 import dev.supergrecko.kllvm.internal.contracts.Validatable
 import dev.supergrecko.kllvm.internal.util.fromLLVMBool
@@ -119,7 +120,7 @@ public class Module internal constructor() : AutoCloseable,
      *
      * @see LLVM.LLVMGetNamedFunction
      */
-    public fun getFunction(name: String): FunctionValue? {
+    public fun getFunction(name: String): Option<FunctionValue> {
         val ref = LLVM.LLVMGetNamedFunction(ref, name)
 
         return wrap(ref) { FunctionValue(it) }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Use.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Use.kt
@@ -1,5 +1,8 @@
 package dev.supergrecko.kllvm.ir
 
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Some
 import org.bytedeco.llvm.LLVM.LLVMUseRef
 import org.bytedeco.llvm.global.LLVM
 
@@ -20,13 +23,13 @@ public class Use internal constructor() {
      * This should be used with [Value.getFirstUse] as this continues the
      * underlying C++ iterator.
      */
-    public fun nextUse(): Use? {
+    public fun nextUse(): Option<Use> {
         val use = LLVM.LLVMGetNextUse(ref)
 
         return if (use != null) {
-            Use(use)
+            Some(Use(use))
         } else {
-            null
+            None
         }
     }
 

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/Value.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.ir
 
+import arrow.core.Option
 import dev.supergrecko.kllvm.internal.contracts.ContainsReference
 import dev.supergrecko.kllvm.internal.contracts.OrderedEnum
 import dev.supergrecko.kllvm.internal.contracts.Unreachable
@@ -208,7 +209,7 @@ public open class Value internal constructor() :
      *
      * @see LLVM.LLVMGetFirstUse
      */
-    public fun getFirstUse(): Use? {
+    public fun getFirstUse(): Option<Use> {
         val use = LLVM.LLVMGetFirstUse(ref)
 
         return wrap(use) { Use(it) }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/types/IntType.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/types/IntType.kt
@@ -7,7 +7,8 @@ import dev.supergrecko.kllvm.ir.values.constants.ConstantInt
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
-public class IntType internal constructor() : Type() {
+public class
+IntType internal constructor() : Type() {
     /**
      * Construct a new Type from an LLVM pointer reference
      */

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/FunctionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/FunctionValue.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.ir.values
 
+import arrow.core.Option
 import dev.supergrecko.kllvm.internal.contracts.Unreachable
 import dev.supergrecko.kllvm.internal.util.fromLLVMBool
 import dev.supergrecko.kllvm.internal.util.map
@@ -57,7 +58,7 @@ public open class FunctionValue internal constructor() : Value() {
      *
      * @see LLVM.LLVMGetEntryBasicBlock
      */
-    public fun getEntryBlock(): BasicBlock? {
+    public fun getEntryBlock(): Option<BasicBlock> {
         val bb = LLVM.LLVMGetEntryBasicBlock(ref)
 
         return wrap(bb) { BasicBlock(it) }
@@ -71,7 +72,7 @@ public open class FunctionValue internal constructor() : Value() {
      *
      * @see LLVM.LLVMGetFirstBasicBlock
      */
-    public fun getFirstBlock(): BasicBlock? {
+    public fun getFirstBlock(): Option<BasicBlock> {
         val bb = LLVM.LLVMGetFirstBasicBlock(ref)
 
         return wrap(bb) { BasicBlock(it) }
@@ -85,7 +86,7 @@ public open class FunctionValue internal constructor() : Value() {
      *
      * @see LLVM.LLVMGetLastBasicBlock
      */
-    public fun getLastBlock(): BasicBlock? {
+    public fun getLastBlock(): Option<BasicBlock> {
         val bb = LLVM.LLVMGetLastBasicBlock(ref)
 
         return wrap(bb) { BasicBlock(it) }
@@ -160,7 +161,7 @@ public open class FunctionValue internal constructor() : Value() {
     //endregion Core::Values::Constants::FunctionValues::FunctionParameters
 
     //region Core::Values::Constants::FunctionValues::IndirectFunctions
-    public fun getIndirectResolver(): IndirectFunction? {
+    public fun getIndirectResolver(): Option<IndirectFunction> {
         val resolver = LLVM.LLVMGetGlobalIFuncResolver(ref)
 
         return wrap(resolver) { IndirectFunction(it) }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariable.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariable.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.kllvm.ir.values
 
+import arrow.core.Option
 import dev.supergrecko.kllvm.internal.util.fromLLVMBool
 import dev.supergrecko.kllvm.internal.util.toLLVMBool
 import dev.supergrecko.kllvm.internal.util.wrap
@@ -41,7 +42,7 @@ public class GlobalVariable internal constructor() : Value() {
      *
      * @see LLVM.LLVMGetInitializer
      */
-    public fun getInitializer(): Value? {
+    public fun getInitializer(): Option<Value> {
         val value = LLVM.LLVMGetInitializer(ref)
 
         return wrap(value) { Value(it) }

--- a/src/main/kotlin/dev/supergrecko/kllvm/ir/values/IntrinsicFunction.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/ir/values/IntrinsicFunction.kt
@@ -61,8 +61,7 @@ public class IntrinsicFunction internal constructor() {
         require(isOverloaded()) { "This intrinsic is not overloaded." }
 
         val ptr = SizeTPointer(0)
-        val arr = ArrayList(parameters.map { it.ref })
-            .toTypedArray()
+        val arr = parameters.map { it.ref }.toTypedArray()
 
         return LLVM.LLVMIntrinsicCopyOverloadedName(
             id,
@@ -92,8 +91,7 @@ public class IntrinsicFunction internal constructor() {
         module: Module,
         parameters: List<Type>
     ): FunctionValue {
-        val arr = ArrayList(parameters.map { it.ref })
-            .toTypedArray()
+        val arr = parameters.map { it.ref }.toTypedArray()
 
         val decl = LLVM.LLVMGetIntrinsicDeclaration(
             module.ref,
@@ -111,8 +109,7 @@ public class IntrinsicFunction internal constructor() {
      * @see LLVM.LLVMIntrinsicGetType
      */
     public fun getType(context: Context, parameters: List<Type>): FunctionType {
-        val arr = ArrayList(parameters.map { it.ref })
-            .toTypedArray()
+        val arr = parameters.map { it.ref }.toTypedArray()
 
         val type = LLVM.LLVMIntrinsicGetType(
             context.ref,

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/ModuleTest.kt
@@ -1,8 +1,11 @@
 package dev.supergrecko.kllvm.ir
 
+import arrow.core.None
+import arrow.core.Some
 import dev.supergrecko.kllvm.ir.types.FunctionType
 import dev.supergrecko.kllvm.ir.types.IntType
 import dev.supergrecko.kllvm.ir.types.VoidType
+import dev.supergrecko.kllvm.ir.values.FunctionValue
 import dev.supergrecko.kllvm.support.VerifierFailureAction
 import java.io.File
 import kotlin.test.assertEquals
@@ -10,6 +13,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.test.fail
 
 class ModuleTest {
     @Test
@@ -54,7 +58,9 @@ class ModuleTest {
     fun `pulling an unknown function from a module is null`() {
         val module = Module("test.ll")
 
-        assertNull(module.getFunction("test"))
+        val fn = module.getFunction("test")
+
+        assertTrue { fn.isEmpty() }
 
         module.dispose()
     }

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariableTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/values/GlobalVariableTest.kt
@@ -1,7 +1,10 @@
 package dev.supergrecko.kllvm.ir.values
 
+import arrow.core.None
+import arrow.core.Some
 import dev.supergrecko.kllvm.ir.Module
 import dev.supergrecko.kllvm.ir.ThreadLocalMode
+import dev.supergrecko.kllvm.ir.Value
 import dev.supergrecko.kllvm.ir.types.IntType
 import dev.supergrecko.kllvm.ir.values.constants.ConstantInt
 import dev.supergrecko.kllvm.test.runAll
@@ -11,6 +14,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class GlobalVariableTest {
     @Test
@@ -28,9 +32,10 @@ class GlobalVariableTest {
             assertFalse { isThreadLocal() }
             assertFalse { isExternallyInitialized() }
 
-            val initializer = value.getInitializer()
-                ?.asIntValue()
-                ?.getSignedValue()
+            val initializer = when (val init = value.getInitializer()) {
+                is Some<Value> -> init.t.asIntValue().getSignedValue()
+                is None -> fail()
+            }
 
             assertEquals(100L, initializer)
             assertEquals("v", getName())
@@ -61,7 +66,7 @@ class GlobalVariableTest {
         val module = Module("test.ll")
         val v = module.addGlobal("v", IntType(32), 0x03f7d)
 
-        assertNull(v.getInitializer())
+        assertTrue { v.getInitializer().isEmpty() }
 
         module.dispose()
     }


### PR DESCRIPTION
This is an experimental patch which looks at the possibilities of using ArrowKt for things like Option<T> instead of returning null.

The reason I am investigating a solution like this is because it is far too easy to ignore a null in Kotlin which might be very important at runtime. Using a proper Option type provides more incentive to properly check what you received from each function.

This PR is primarily a proof-of-concept.