### PR TITLE
Experiment: Try using IsA and Iterator to facilitate LLVM Iterators

### DIFF
--- a/src/main/kotlin/dev/supergrecko/kllvm/internal/contracts/IsA.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/internal/contracts/IsA.kt
@@ -1,0 +1,16 @@
+package dev.supergrecko.kllvm.internal.contracts
+
+/**
+ * A type which provides a set of IsA operators
+ *
+ * This is used for all the IsA functions LLVM generates. The isa operator
+ * can be retrieved from the implementing function isa.
+ */
+public interface LLVMIsA {
+    public fun isa(): IsA
+}
+
+/**
+ * Anything which implements [LLVMIsA] must implement this in an inner class
+ */
+public interface IsA

--- a/src/main/kotlin/dev/supergrecko/kllvm/internal/contracts/Iterator.kt
+++ b/src/main/kotlin/dev/supergrecko/kllvm/internal/contracts/Iterator.kt
@@ -1,0 +1,42 @@
+package dev.supergrecko.kllvm.internal.contracts
+
+/**
+ * An iterator which mimics LLVMs Next* and Prev* iterators
+ *
+ * LLVM exposes its iterators by pulling a First* instance from some type and
+ * then advancing said iterator by calling Next* and Prev* functions on the
+ * returned value.
+ *
+ * Not all iterators have both Next and Prev so the implementation for
+ * [Iterator] is unspecified and therefore [NextIterator] and [PrevIterator]
+ * are provided.
+ */
+public interface LLVMIterable<T> {
+    public fun iter(): Iterator<T>
+}
+
+/**
+ * Anything which implements [LLVMIterable] must implement this in an inner
+ * class
+ *
+ * Represents that this class (usually an inner class for some type LLVM
+ * provides an iterable for) is an unknown iterator
+ *
+ * The child interfaces [NextIterator] and [PrevIterator] describe more about
+ * the iterator
+ */
+public interface Iterator<T>
+
+/**
+ * This iterator can advance forwards
+ */
+public interface NextIterator<T> : Iterator<T> {
+    public fun next(): T?
+}
+
+/**
+ * This iterator can advance backwards
+ */
+public interface PrevIterator<T> : Iterator<T> {
+    public fun prev(): T?
+}

--- a/src/test/kotlin/dev/supergrecko/kllvm/ir/ValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/ir/ValueTest.kt
@@ -47,7 +47,7 @@ class ValueTest {
     @Test
     fun `value type matches`() {
         val type = IntType(32)
-        val value = ConstantInt(type, 1L, true)
+        val value = ConstantInt(type, 1)
 
         val valueType = value.getType()
 
@@ -59,9 +59,9 @@ class ValueTest {
     @Test
     fun `isa checks match`() {
         val type = IntType(32)
-        val value = ConstantInt(type, 1L, true)
+        val value = ConstantInt(type, 1)
 
-        assertFalse { value.isMetadataNode() }
-        assertFalse { value.isMetadataString() }
+        assertFalse { value.isa().metadataNode() }
+        assertFalse { value.isa().metadataString() }
     }
 }


### PR DESCRIPTION
This is an experiment with LLVMIsA and LLVMIterator<T> which are supposed to mimic LLVMs way of exposing iterators and isa-checks

**LLVMIsA**

The different approaches produce equal APIs, but the IsA solution doesn't clutter autocomplete as every IsA check is found under the object returned by .isa().

```kotlin
assertFalse { value.isMetadataNode() }
assertFalse { value.isMetadataString() }
// vs
assertFalse { value.isa().metadataNode() }
assertFalse { value.isa().metadataString() }
```

LLVM exposes a lot (88) IsA checks for the C API as well as a lot of other Is checks which could all be wrapped up and put under the new LLVMIsA interface.

**LLVMIterator<T>**

LLVM-C is incapable of returning the actual C++ iterators to userland which is why it provides a boatload of Next and Prev functions instead of the iterators. Some of which only provide a Next method.

We can put all of these iterators into LLVMIterator<T>'s and we may be able to provide a bridge to Kotlin iterators in the future which would make working with these iterators a lot easier than using LLVM-C's approach.