### PR TITLE
[unittest] Add getTemporaryFile API which deletes file on cleanup

### DIFF
--- a/src/test/kotlin/dev/supergrecko/kllvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/unit/ir/ModuleTest.kt
@@ -80,26 +80,26 @@ internal class ModuleTest : KLLVMTestCase() {
 
     @Test
     fun `Write the module byte-code to file`() {
-        val file = File("./out.bc")
+        val file = getTemporaryFile("out.bc")
         val module = Module("utils.ll").also {
             it.writeBitCodeToFile(file)
         }
 
-        assertTrue { file.exists() }
+        assertTrue { file.length() > 0 }
 
-        cleanup(module) { file.delete() }
+        cleanup(module)
     }
 
     @Test
     fun `Write the module byte-code to file path`() {
-        val file = File("./out.bc")
+        val file = getTemporaryFile("out.bc")
         val module = Module("utils.ll").also {
             it.writeBitCodeToFile(file.absolutePath)
         }
 
         assertTrue { file.exists() }
 
-        cleanup(module) { file.delete() }
+        cleanup(module)
     }
 
     @Test

--- a/src/test/kotlin/dev/supergrecko/kllvm/unit/support/MemoryBufferTest.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/unit/support/MemoryBufferTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
 
-internal class MemoryBufferTestCase : KLLVMTestCase() {
+internal class MemoryBufferTest : KLLVMTestCase() {
     @Test
     fun `The buffer byte-code starts with B for BC`() {
         val context = Context()
@@ -25,12 +25,12 @@ internal class MemoryBufferTestCase : KLLVMTestCase() {
 
     @Test
     fun `Create MemoryBuffer from byte-code file`() {
-        val target = File("utils.ll.2")
+        val file = getTemporaryFile("out.ll")
         val mod = Module("utils.ll")
 
-        mod.writeBitCodeToFile(target)
+        mod.writeBitCodeToFile(file)
 
-        val buf = MemoryBuffer(target)
+        val buf = MemoryBuffer(file)
 
         assertNotNull(buf)
         cleanup(mod, buf)

--- a/src/test/kotlin/dev/supergrecko/kllvm/utils/KLLVMTestCase.kt
+++ b/src/test/kotlin/dev/supergrecko/kllvm/utils/KLLVMTestCase.kt
@@ -2,13 +2,16 @@ package dev.supergrecko.kllvm.utils
 
 import dev.supergrecko.kllvm.unit.internal.contracts.Disposable
 import org.junit.jupiter.api.AfterEach
+import java.io.File
 
 internal open class KLLVMTestCase {
     internal val allocator = DisposablePool()
+    internal val files = FilePool()
 
     @AfterEach
     fun onTearDown() {
         allocator.reset()
+        files.reset()
     }
 
     /**
@@ -16,16 +19,23 @@ internal open class KLLVMTestCase {
      *
      * These are put into [allocator] and automatically disposed via
      * [onTearDown]
-     *
-     * You may also pass an [also] callback to do additional cleanup tasks
      */
     internal fun cleanup(
-        vararg disposables: Disposable,
-        also: (() -> Unit)? = null
+        vararg disposables: Disposable
     ) {
         allocator.pool.addAll(disposables)
+    }
 
-        also?.let { also() }
+    /**
+     * Get a file which will only exist for the current test case.
+     *
+     * File is automatically erased and deleted after test case lifecycle is
+     * over
+     */
+    fun getTemporaryFile(name: String): File {
+        return File.createTempFile(name, "").also {
+            files.pool.add(it)
+        }
     }
 
     /**
@@ -43,6 +53,14 @@ internal open class KLLVMTestCase {
         internal fun reset() {
             pool.filter { it.valid }.forEach { it.dispose() }
             pool.removeAll(pool)
+        }
+    }
+
+    internal class FilePool {
+        internal val pool: MutableList<File> = mutableListOf()
+
+        internal fun reset() {
+            pool.filter { it.exists()}.map { it.delete() }
         }
     }
 }


### PR DESCRIPTION
This adds a getTemporaryFile which creates a file in the temporary directory which is deleted after the test case is done.