### PR TITLE
[llvm] Implement ModuleProvider bindings

### DIFF
--- a/vexe-llvm/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/vexe-llvm/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -524,14 +524,6 @@ public class Module internal constructor() : AutoCloseable,
     }
     //endregion BitWriter
 
-    public override fun dispose() {
-        require(valid) { "This module has already been disposed." }
-
-        valid = false
-
-        LLVM.LLVMDisposeModule(ref)
-    }
-
     //region Analysis
     /**
      * Verifies that the module structure is valid
@@ -560,6 +552,27 @@ public class Module internal constructor() : AutoCloseable,
         return !res.fromLLVMBool()
     }
     //endregion Analysis
+
+    //region ModuleProviders
+    /**
+     * Changes the type of this to a ModuleProvider
+     *
+     * According to LLVM this is for historical reasons
+     *
+     * @see LLVM.LLVMCreateModuleProviderForExistingModules
+     */
+    public fun getModuleProvider(): ModuleProvider {
+        return ModuleProvider(this)
+    }
+    //endregion ModuleProviders
+
+    public override fun dispose() {
+        require(valid) { "This module has already been disposed." }
+
+        valid = false
+
+        LLVM.LLVMDisposeModule(ref)
+    }
 
     public override fun close() = dispose()
 }

--- a/vexe-llvm/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleProvider.kt
+++ b/vexe-llvm/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleProvider.kt
@@ -9,15 +9,20 @@ import org.bytedeco.llvm.global.LLVM
 public class ModuleProvider internal constructor() :
     AutoCloseable, Validatable, Disposable,
     ContainsReference<LLVMModuleProviderRef> {
+    private lateinit var module: Module
     public override lateinit var ref: LLVMModuleProviderRef
     public override var valid: Boolean = true
 
-    public constructor(provider: LLVMModuleProviderRef) : this() {
-        ref = provider
+    public constructor(parent: Module) {
+        require(parent.valid) { "Cannot retrieve Module Provider of deleted " +
+                "module" }
+        module = parent
+        ref = LLVM.LLVMCreateModuleProviderForExistingModule(parent.ref)
     }
 
     override fun dispose() {
         require(valid) { "This module has already been disposed." }
+
 
         valid = false
 

--- a/vexe-llvm/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleProvider.kt
+++ b/vexe-llvm/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleProvider.kt
@@ -13,7 +13,7 @@ public class ModuleProvider internal constructor() :
     public override lateinit var ref: LLVMModuleProviderRef
     public override var valid: Boolean = true
 
-    public constructor(parent: Module) {
+    public constructor(parent: Module) : this() {
         require(parent.valid) { "Cannot retrieve Module Provider of deleted " +
                 "module" }
         module = parent


### PR DESCRIPTION
Closes #14 

Implements the bindings to convert a Module into a ModuleProvider.