### PR TITLE
[api] Implement Kotlin based Lambda API for LLVM Callbacks

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/MCJITMemoryManager.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/MCJITMemoryManager.kt
@@ -1,14 +1,18 @@
 package dev.supergrecko.vexe.llvm.executionengine
 
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerAllocateCodeSectionBase
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerAllocateCodeSectionCallback
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerAllocateDataSectionBase
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerAllocateDataSectionCallback
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerDestroyBase
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerDestroyCallback
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerFinalizeMemoryBase
+import dev.supergrecko.vexe.llvm.executionengine.callbacks.MemoryManagerFinalizeMemoryCallback
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import dev.supergrecko.vexe.llvm.internal.contracts.Disposable
 import dev.supergrecko.vexe.llvm.internal.contracts.Validatable
 import org.bytedeco.javacpp.Pointer
 import org.bytedeco.llvm.LLVM.LLVMMCJITMemoryManagerRef
-import org.bytedeco.llvm.LLVM.LLVMMemoryManagerAllocateCodeSectionCallback
-import org.bytedeco.llvm.LLVM.LLVMMemoryManagerAllocateDataSectionCallback
-import org.bytedeco.llvm.LLVM.LLVMMemoryManagerDestroyCallback
-import org.bytedeco.llvm.LLVM.LLVMMemoryManagerFinalizeMemoryCallback
 import org.bytedeco.llvm.global.LLVM
 
 public class MCJITMemoryManager internal constructor() :
@@ -30,23 +34,21 @@ public class MCJITMemoryManager internal constructor() :
      * callbacks. You may pass a [client] which will be passed into each
      * callback upon call.
      *
-     * TODO: Replace callbacks with Kotlin Lambda
-     *
      * @see LLVM.LLVMCreateSimpleMCJITMemoryManager
      */
     public constructor(
         client: Pointer,
-        onAllocateCode: LLVMMemoryManagerAllocateCodeSectionCallback,
-        onAllocateData: LLVMMemoryManagerAllocateDataSectionCallback,
-        onFinalizeMemory: LLVMMemoryManagerFinalizeMemoryCallback,
-        onManagerDestroy: LLVMMemoryManagerDestroyCallback
+        onAllocateCode: MemoryManagerAllocateCodeSectionCallback,
+        onAllocateData: MemoryManagerAllocateDataSectionCallback,
+        onFinalizeMemory: MemoryManagerFinalizeMemoryCallback,
+        onManagerDestroy: MemoryManagerDestroyCallback
     ) : this() {
         ref = LLVM.LLVMCreateSimpleMCJITMemoryManager(
             client,
-            onAllocateCode,
-            onAllocateData,
-            onFinalizeMemory,
-            onManagerDestroy
+            MemoryManagerAllocateCodeSectionBase(onAllocateCode),
+            MemoryManagerAllocateDataSectionBase(onAllocateData),
+            MemoryManagerFinalizeMemoryBase(onFinalizeMemory),
+            MemoryManagerDestroyBase(onManagerDestroy)
         )
     }
     //endregion ExecutionEngine

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateCodeSectionCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateCodeSectionCallback.kt
@@ -1,0 +1,24 @@
+package dev.supergrecko.vexe.llvm.executionengine.callbacks
+
+import dev.supergrecko.vexe.llvm.internal.contracts.Callback
+import org.bytedeco.javacpp.BytePointer
+import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMMemoryManagerAllocateCodeSectionCallback
+
+public typealias MemoryManagerAllocateCodeSectionCallback = (
+    Pointer?, Long, Int, Int, BytePointer?
+) -> BytePointer
+
+public class MemoryManagerAllocateCodeSectionBase(
+    private val callback: MemoryManagerAllocateCodeSectionCallback
+) : LLVMMemoryManagerAllocateCodeSectionCallback(), Callback {
+    public override fun call(
+        arg0: Pointer?,
+        arg1: Long,
+        arg2: Int,
+        arg3: Int,
+        arg4: BytePointer?
+    ): BytePointer {
+        return callback.invoke(arg0, arg1, arg2, arg3, arg4)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateDataSectionCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateDataSectionCallback.kt
@@ -1,0 +1,28 @@
+package dev.supergrecko.vexe.llvm.executionengine.callbacks
+
+import dev.supergrecko.vexe.llvm.internal.contracts.Callback
+import dev.supergrecko.vexe.llvm.internal.util.fromLLVMBool
+import org.bytedeco.javacpp.BytePointer
+import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMMemoryManagerAllocateDataSectionCallback
+
+public typealias MemoryManagerAllocateDataSectionCallback = (
+    Pointer?, Long, Int, Int, BytePointer?, Boolean
+) -> BytePointer
+
+public class MemoryManagerAllocateDataSectionBase(
+    private val callback: MemoryManagerAllocateDataSectionCallback
+) : LLVMMemoryManagerAllocateDataSectionCallback(), Callback {
+    public override fun call(
+        arg0: Pointer?,
+        arg1: Long,
+        arg2: Int,
+        arg3: Int,
+        arg4: BytePointer?,
+        arg5: Int
+    ): BytePointer {
+        val bool = arg5.fromLLVMBool()
+
+        return callback.invoke(arg0, arg1, arg2, arg3, arg4, bool)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerDestroyCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerDestroyCallback.kt
@@ -1,0 +1,17 @@
+package dev.supergrecko.vexe.llvm.executionengine.callbacks
+
+import dev.supergrecko.vexe.llvm.internal.contracts.Callback
+import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMMemoryManagerDestroyCallback
+
+public typealias MemoryManagerDestroyCallback = (
+    Pointer?
+) -> Unit
+
+public class MemoryManagerDestroyBase(
+    private val callback: MemoryManagerDestroyCallback
+) : LLVMMemoryManagerDestroyCallback(), Callback {
+    public override fun call(arg0: Pointer?) {
+        callback.invoke(arg0)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerFinalizeMemoryCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerFinalizeMemoryCallback.kt
@@ -1,0 +1,20 @@
+package dev.supergrecko.vexe.llvm.executionengine.callbacks
+
+import dev.supergrecko.vexe.llvm.internal.contracts.Callback
+import org.bytedeco.javacpp.BytePointer
+import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMMemoryManagerFinalizeMemoryCallback
+
+public typealias MemoryManagerFinalizeMemoryCallback = (
+    Pointer?, String?
+) -> Int
+
+public class MemoryManagerFinalizeMemoryBase(
+    private val callback: MemoryManagerFinalizeMemoryCallback
+) : LLVMMemoryManagerFinalizeMemoryCallback(), Callback {
+    public override fun call(arg0: Pointer?, arg1: BytePointer?): Int {
+        val msg = arg1?.string
+
+        return callback.invoke(arg0, msg)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/Callback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/Callback.kt
@@ -1,0 +1,14 @@
+package dev.supergrecko.vexe.llvm.internal.contracts
+
+import org.bytedeco.javacpp.Pointer
+
+/**
+ * Indicates that the implementor is a callback to a LLVM callback function
+ *
+ * Each callback definition is declared inside its own file, with its own
+ * typealias which describes the Kotlin Lambda type expected.
+ *
+ * A callback wraps around a [Pointer] which is being passed to the
+ * LLVM C APIs callback setter
+ */
+public interface Callback

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/DiagnosticHandlerCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/DiagnosticHandlerCallback.kt
@@ -1,0 +1,27 @@
+package dev.supergrecko.vexe.llvm.ir.callbacks
+
+import dev.supergrecko.vexe.llvm.internal.contracts.Callback
+import dev.supergrecko.vexe.llvm.internal.util.wrap
+import dev.supergrecko.vexe.llvm.ir.DiagnosticInfo
+import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMDiagnosticHandler
+import org.bytedeco.llvm.LLVM.LLVMDiagnosticInfoRef
+
+/**
+ * This callback is invoked when the backend needs to report anything to the
+ * user
+ *
+ * [DiagnosticInfo] The associated DiagnosticInfo reporter
+ * [Pointer] The payload which was sent with the setter for this callback
+ */
+public typealias DiagnosticHandlerCallback = (DiagnosticInfo?, Pointer?) -> Unit
+
+public class DiagnosticHandlerBase(
+    private val callback: DiagnosticHandlerCallback
+) : LLVMDiagnosticHandler(), Callback {
+    public override fun call(arg0: LLVMDiagnosticInfoRef?, arg1: Pointer?) {
+        val di = wrap(arg0) { DiagnosticInfo(it) }
+
+        callback.invoke(di, arg1)
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/YieldCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/YieldCallback.kt
@@ -1,0 +1,28 @@
+package dev.supergrecko.vexe.llvm.ir.callbacks
+
+import dev.supergrecko.vexe.llvm.internal.contracts.Callback
+import dev.supergrecko.vexe.llvm.internal.util.wrap
+import dev.supergrecko.vexe.llvm.ir.Context
+import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMContextRef
+import org.bytedeco.llvm.LLVM.LLVMYieldCallback
+
+/**
+ * The yield callback function may be called by LLVM to transfer control back
+ * to the client that invoked the LLVM compilation. There is no guarantee
+ * that this callback ever goes off.
+ *
+ * [Context] The context this was set to
+ * [Pointer] The payload which was sent with the setter for this callback
+ */
+public typealias YieldCallback = (Context?, Pointer?) -> Unit
+
+public class YieldCallbackBase(
+    private val callback: YieldCallback
+) : LLVMYieldCallback(), Callback {
+    public override fun call(arg0: LLVMContextRef?, arg1: Pointer?) {
+        val ctx = wrap(arg0) { Context(it) }
+
+        callback.invoke(ctx, arg1)
+    }
+}

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/CallbackTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/CallbackTest.kt
@@ -1,0 +1,18 @@
+package dev.supergrecko.vexe.llvm.unit.internal
+
+import dev.supergrecko.vexe.llvm.ir.Context
+import dev.supergrecko.vexe.llvm.utils.cleanup
+import dev.supergrecko.vexe.test.TestSuite
+
+internal class CallbackTest : TestSuite({
+    describe("Creating a callback") {
+        val ctx = Context().apply {
+            // Kotlin lambdas!
+            setDiagnosticHandler({ _, _ ->
+
+            })
+        }
+
+        cleanup(ctx)
+    }
+})

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ContextTest.kt
@@ -17,22 +17,6 @@ internal class ContextTest : TestSuite({
         ctx.dispose()
     }
 
-    describe("Passing a callback hook") {
-        // TODO: Rewrite these with kt lambdas
-        val handler = object : LLVMDiagnosticHandler() {
-            override fun call(p0: LLVMDiagnosticInfoRef?, p1: Pointer?) {
-            }
-        }
-        val ctx = Context().apply {
-            setDiagnosticHandler(handler)
-        }
-        val res: LLVMDiagnosticHandler? = ctx.getDiagnosticHandler()
-
-        assertNotNull(res)
-
-        cleanup(ctx)
-    }
-
     describe("Mutating discard value names") {
         val ctx = Context()
 


### PR DESCRIPTION
Our JNI solutions uses JVM objects with methods to implement callbacks, similar to how Java did it before FunctionalInterface. This PR implements Kotlin Lambdas as an interface to these APIs as you'd expect from a Kotlin library.