### PR TITLE
[refactor] Rename constant instruction APIs to getN instead of N

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
@@ -4,7 +4,7 @@ import dev.supergrecko.vexe.llvm.internal.contracts.Unreachable
 import dev.supergrecko.vexe.llvm.internal.contracts.Validatable
 import dev.supergrecko.vexe.llvm.internal.util.fromLLVMBool
 import dev.supergrecko.vexe.llvm.internal.util.wrap
-import dev.supergrecko.vexe.llvm.ir.values.DebugLocationValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.DebugLocationValue
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/ArrayType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/ArrayType.kt
@@ -1,11 +1,14 @@
 package dev.supergrecko.vexe.llvm.ir.types
 
 import dev.supergrecko.vexe.llvm.ir.Type
+import dev.supergrecko.vexe.llvm.ir.types.traits.CompositeType
+import dev.supergrecko.vexe.llvm.ir.types.traits.SequentialType
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class ArrayType internal constructor() : Type(),
-    CompositeType, SequentialType {
+    CompositeType,
+    SequentialType {
     public constructor(llvmRef: LLVMTypeRef) : this() {
         ref = llvmRef
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/PointerType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/PointerType.kt
@@ -1,11 +1,14 @@
 package dev.supergrecko.vexe.llvm.ir.types
 
 import dev.supergrecko.vexe.llvm.ir.Type
+import dev.supergrecko.vexe.llvm.ir.types.traits.CompositeType
+import dev.supergrecko.vexe.llvm.ir.types.traits.SequentialType
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class PointerType internal constructor() : Type(),
-    CompositeType, SequentialType {
+    CompositeType,
+    SequentialType {
     public constructor(llvmRef: LLVMTypeRef) : this() {
         ref = llvmRef
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/StructType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/StructType.kt
@@ -5,6 +5,7 @@ import dev.supergrecko.vexe.llvm.internal.util.map
 import dev.supergrecko.vexe.llvm.internal.util.toLLVMBool
 import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Type
+import dev.supergrecko.vexe.llvm.ir.types.traits.CompositeType
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/VectorType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/VectorType.kt
@@ -1,11 +1,14 @@
 package dev.supergrecko.vexe.llvm.ir.types
 
 import dev.supergrecko.vexe.llvm.ir.Type
+import dev.supergrecko.vexe.llvm.ir.types.traits.CompositeType
+import dev.supergrecko.vexe.llvm.ir.types.traits.SequentialType
 import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.global.LLVM
 
 public class VectorType internal constructor() : Type(),
-    CompositeType, SequentialType {
+    CompositeType,
+    SequentialType {
     public constructor(llvmType: LLVMTypeRef) : this() {
         ref = llvmType
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/traits/CompositeType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/traits/CompositeType.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.vexe.llvm.ir.types
+package dev.supergrecko.vexe.llvm.ir.types.traits
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import org.bytedeco.llvm.LLVM.LLVMTypeRef

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/traits/SequentialType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/traits/SequentialType.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.vexe.llvm.ir.types
+package dev.supergrecko.vexe.llvm.ir.types.traits
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import dev.supergrecko.vexe.llvm.ir.Type

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/FunctionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/FunctionValue.kt
@@ -11,6 +11,7 @@ import dev.supergrecko.vexe.llvm.ir.CallConvention
 import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Module
 import dev.supergrecko.vexe.llvm.ir.Value
+import dev.supergrecko.vexe.llvm.ir.values.traits.DebugLocationValue
 import dev.supergrecko.vexe.llvm.ir.types.FunctionType
 import dev.supergrecko.vexe.llvm.support.VerifierFailureAction
 import org.bytedeco.javacpp.PointerPointer

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalValue.kt
@@ -10,6 +10,7 @@ import dev.supergrecko.vexe.llvm.ir.Type
 import dev.supergrecko.vexe.llvm.ir.UnnamedAddress
 import dev.supergrecko.vexe.llvm.ir.Value
 import dev.supergrecko.vexe.llvm.ir.Visibility
+import dev.supergrecko.vexe.llvm.ir.values.traits.ConstantValue
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
@@ -37,7 +38,8 @@ public enum class Linkage(public override val value: Int) : OrderedEnum<Int> {
     PrivateWeak(LLVM.LLVMLinkerPrivateWeakLinkage),
 }
 
-public open class GlobalValue internal constructor() : Value(), ConstantValue {
+public open class GlobalValue internal constructor() : Value(),
+    ConstantValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalVariable.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalVariable.kt
@@ -5,6 +5,7 @@ import dev.supergrecko.vexe.llvm.internal.util.toLLVMBool
 import dev.supergrecko.vexe.llvm.internal.util.wrap
 import dev.supergrecko.vexe.llvm.ir.ThreadLocalMode
 import dev.supergrecko.vexe.llvm.ir.Value
+import dev.supergrecko.vexe.llvm.ir.values.traits.DebugLocationValue
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantArray.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantArray.kt
@@ -5,16 +5,18 @@ import dev.supergrecko.vexe.llvm.internal.util.toLLVMBool
 import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Type
 import dev.supergrecko.vexe.llvm.ir.Value
-import dev.supergrecko.vexe.llvm.ir.values.AggregateValue
-import dev.supergrecko.vexe.llvm.ir.values.CompositeValue
-import dev.supergrecko.vexe.llvm.ir.values.ConstantValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.AggregateValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.CompositeValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.ConstantValue
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ConstantArray internal constructor() : Value(), ConstantValue,
-    AggregateValue, CompositeValue {
+public class ConstantArray internal constructor() : Value(),
+    ConstantValue,
+    AggregateValue,
+    CompositeValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantFloat.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantFloat.kt
@@ -5,11 +5,12 @@ import dev.supergrecko.vexe.llvm.ir.RealPredicate
 import dev.supergrecko.vexe.llvm.ir.Value
 import dev.supergrecko.vexe.llvm.ir.types.FloatType
 import dev.supergrecko.vexe.llvm.ir.types.IntType
-import dev.supergrecko.vexe.llvm.ir.values.ConstantValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.ConstantValue
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ConstantFloat internal constructor() : Value(), ConstantValue {
+public class ConstantFloat internal constructor() : Value(),
+    ConstantValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef
     }
@@ -57,7 +58,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstFNeg
      */
-    public fun neg(): ConstantFloat {
+    public fun getNeg(): ConstantFloat {
         val ref = LLVM.LLVMConstFNeg(ref)
 
         return ConstantFloat(ref)
@@ -71,7 +72,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstFAdd
      */
-    public fun add(rhs: ConstantFloat): ConstantFloat {
+    public fun getAdd(rhs: ConstantFloat): ConstantFloat {
         val ref = LLVM.LLVMConstFAdd(ref, rhs.ref)
 
         return ConstantFloat(ref)
@@ -85,7 +86,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstFSub
      */
-    public fun sub(rhs: ConstantFloat): ConstantFloat {
+    public fun getSub(rhs: ConstantFloat): ConstantFloat {
         val ref = LLVM.LLVMConstFSub(ref, rhs.ref)
 
         return ConstantFloat(ref)
@@ -96,7 +97,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstFMul
      */
-    public fun mul(rhs: ConstantFloat): ConstantFloat {
+    public fun getMul(rhs: ConstantFloat): ConstantFloat {
         val ref = LLVM.LLVMConstFMul(ref, rhs.ref)
 
         return ConstantFloat(ref)
@@ -107,7 +108,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstFDiv
      */
-    public fun div(rhs: ConstantFloat): ConstantFloat {
+    public fun getDiv(rhs: ConstantFloat): ConstantFloat {
         val ref = LLVM.LLVMConstFDiv(ref, rhs.ref)
 
         return ConstantFloat(ref)
@@ -118,7 +119,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMFRem
      */
-    public fun rem(rhs: ConstantFloat): ConstantFloat {
+    public fun getRem(rhs: ConstantFloat): ConstantFloat {
         val ref = LLVM.LLVMConstFRem(ref, rhs.ref)
 
         return ConstantFloat(ref)
@@ -132,7 +133,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstFCmp
      */
-    public fun cmp(
+    public fun getFCmp(
         predicate: RealPredicate,
         rhs: ConstantFloat
     ): ConstantFloat {
@@ -148,10 +149,8 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      * sizes are not allowed
      *
      * @see LLVM.LLVMConstFPTrunc
-     *
-     * TODO: Find a way to check type sizes
      */
-    public fun trunc(type: FloatType): ConstantFloat {
+    public fun getTrunc(type: FloatType): ConstantFloat {
         val ref = LLVM.LLVMConstFPTrunc(ref, type.ref)
 
         return ConstantFloat(ref)
@@ -164,10 +163,8 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      * destination type
      *
      * @see LLVM.LLVMConstFPExt
-     *
-     * TODO: Find a way to check type sizes
      */
-    public fun ext(type: FloatType): ConstantFloat {
+    public fun getExt(type: FloatType): ConstantFloat {
         val ref = LLVM.LLVMConstFPExt(ref, type.ref)
 
         return ConstantFloat(ref)
@@ -177,10 +174,8 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      * Conversion to signed integer type
      *
      * @see LLVM.LLVMConstFPToSI
-     *
-     * TODO: Find a way to check if type is signed
      */
-    public fun fptosi(type: IntType): ConstantInt {
+    public fun getFPToSI(type: IntType): ConstantInt {
         val ref = LLVM.LLVMConstFPToSI(ref, type.ref)
 
         return ConstantInt(ref)
@@ -190,10 +185,8 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      * Conversion to unsigned integer type
      *
      * @see LLVM.LLVMConstFPToUI
-     *
-     * TODO: Find a way to check if type is signed
      */
-    public fun fptoui(type: IntType): ConstantInt {
+    public fun getFPToUI(type: IntType): ConstantInt {
         val ref = LLVM.LLVMConstFPToUI(ref, type.ref)
 
         return ConstantInt(ref)
@@ -204,7 +197,7 @@ public class ConstantFloat internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstFPCast
      */
-    public fun fpcast(type: FloatType): ConstantFloat {
+    public fun getFPCast(type: FloatType): ConstantFloat {
         val ref = LLVM.LLVMConstFPCast(ref, type.ref)
 
         return ConstantFloat(ref)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantInt.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantInt.kt
@@ -7,11 +7,12 @@ import dev.supergrecko.vexe.llvm.ir.Value
 import dev.supergrecko.vexe.llvm.ir.types.FloatType
 import dev.supergrecko.vexe.llvm.ir.types.IntType
 import dev.supergrecko.vexe.llvm.ir.types.PointerType
-import dev.supergrecko.vexe.llvm.ir.values.ConstantValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.ConstantValue
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ConstantInt internal constructor() : Value(), ConstantValue {
+public class ConstantInt internal constructor() : Value(),
+    ConstantValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef
     }
@@ -88,7 +89,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstNeg
      */
-    public fun neg(
+    public fun getNeg(
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
     ): ConstantInt {
@@ -108,7 +109,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstNot
      */
-    public fun not(): ConstantInt {
+    public fun getNot(): ConstantInt {
         val ref = LLVM.LLVMConstNot(ref)
 
         return ConstantInt(ref)
@@ -127,7 +128,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstAdd
      */
-    public fun add(
+    public fun getAdd(
         rhs: ConstantInt,
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
@@ -156,7 +157,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstSub
      */
-    public fun sub(
+    public fun getSub(
         rhs: ConstantInt,
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
@@ -185,7 +186,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstMul
      */
-    public fun mul(
+    public fun getMul(
         rhs: ConstantInt,
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
@@ -219,7 +220,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      * @see LLVM.LLVMConstUDiv
      * @see LLVM.LLVMConstSDiv
      */
-    public fun div(
+    public fun getDiv(
         rhs: ConstantInt,
         exact: Boolean,
         unsigned: Boolean
@@ -247,10 +248,10 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstUDiv
      */
-    public fun udiv(
+    public fun getUDiv(
         rhs: ConstantInt,
         exact: Boolean
-    ): ConstantInt = div(rhs, exact, true)
+    ): ConstantInt = getDiv(rhs, exact, true)
 
     /**
      * Perform division with another signed integer vector
@@ -265,10 +266,10 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstSDiv
      */
-    public fun sdiv(
+    public fun getSDiv(
         rhs: ConstantInt,
         exact: Boolean
-    ): ConstantInt = div(rhs, exact, false)
+    ): ConstantInt = getDiv(rhs, exact, false)
 
     /**
      * Get the remainder from the division of the two operands
@@ -280,7 +281,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      * @see LLVM.LLVMSRem
      * @see LLVM.LLVMURem
      */
-    public fun rem(rhs: ConstantInt, unsigned: Boolean): ConstantInt {
+    public fun getRem(rhs: ConstantInt, unsigned: Boolean): ConstantInt {
         val ref = if (unsigned) {
             LLVM.LLVMConstURem(ref, rhs.ref)
         } else {
@@ -297,7 +298,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMURem
      */
-    public fun urem(rhs: ConstantInt): ConstantInt = rem(rhs, true)
+    public fun getURem(rhs: ConstantInt): ConstantInt = getRem(rhs, true)
 
     /**
      * Get the remainder from the division of the two operands
@@ -306,7 +307,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMSRem
      */
-    public fun srem(rhs: ConstantInt): ConstantInt = rem(rhs, false)
+    public fun getSRem(rhs: ConstantInt): ConstantInt = getRem(rhs, false)
 
     /**
      * Perform bitwise logical and for the two operands
@@ -321,7 +322,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstAdd
      */
-    public fun and(rhs: ConstantInt): ConstantInt {
+    public fun getAnd(rhs: ConstantInt): ConstantInt {
         val ref = LLVM.LLVMConstAnd(ref, rhs.ref)
 
         return ConstantInt(ref)
@@ -340,7 +341,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstOr
      */
-    public fun or(rhs: ConstantInt): ConstantInt {
+    public fun getOr(rhs: ConstantInt): ConstantInt {
         val ref = LLVM.LLVMConstOr(ref, rhs.ref)
 
         return ConstantInt(ref)
@@ -359,7 +360,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstXor
      */
-    public fun xor(rhs: ConstantInt): ConstantInt {
+    public fun getXor(rhs: ConstantInt): ConstantInt {
         val ref = LLVM.LLVMConstXor(ref, rhs.ref)
 
         return ConstantInt(ref)
@@ -373,7 +374,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstICmp
      */
-    public fun cmp(predicate: IntPredicate, rhs: ConstantInt): ConstantInt {
+    public fun getICmp(predicate: IntPredicate, rhs: ConstantInt): ConstantInt {
         val ref = LLVM.LLVMConstICmp(predicate.value, ref, rhs.ref)
 
         return ConstantInt(ref)
@@ -386,7 +387,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstShl
      */
-    public fun shl(bits: ConstantInt): ConstantInt {
+    public fun getShl(bits: ConstantInt): ConstantInt {
         val ref = LLVM.LLVMConstShl(ref, bits.ref)
 
         return ConstantInt(ref)
@@ -400,7 +401,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstLShr
      */
-    public fun lshr(bits: ConstantInt): ConstantInt {
+    public fun getLShr(bits: ConstantInt): ConstantInt {
         val ref = LLVM.LLVMConstLShr(ref, bits.ref)
 
         return ConstantInt(ref)
@@ -414,7 +415,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstAShr
      */
-    public fun ashr(bits: ConstantInt): ConstantInt {
+    public fun getAShr(bits: ConstantInt): ConstantInt {
         val ref = LLVM.LLVMConstAShr(ref, bits.ref)
 
         return ConstantInt(ref)
@@ -428,7 +429,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstTrunc
      */
-    public fun trunc(type: IntType): ConstantInt {
+    public fun getTrunc(type: IntType): ConstantInt {
         val ref = LLVM.LLVMConstTrunc(ref, type.ref)
 
         return ConstantInt(ref)
@@ -443,7 +444,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      * @see LLVM.LLVMConstSExt
      * @see LLVM.LLVMConstZExt
      */
-    public fun ext(type: IntType, signExtend: Boolean): ConstantInt {
+    public fun getExt(type: IntType, signExtend: Boolean): ConstantInt {
         val ref = if (signExtend) {
             LLVM.LLVMConstSExt(ref, type.ref)
         } else {
@@ -461,7 +462,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstSExt
      */
-    public fun sext(type: IntType): ConstantInt = ext(type, true)
+    public fun getSExt(type: IntType): ConstantInt = getExt(type, true)
 
     /**
      * Zero extend this value to type [type]
@@ -471,7 +472,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstZExt
      */
-    public fun zext(type: IntType): ConstantInt = ext(type, false)
+    public fun getZExt(type: IntType): ConstantInt = getExt(type, false)
 
     /**
      * Converstion to float type
@@ -479,7 +480,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      * @see LLVM.LLVMConstSIToFP
      * @see LLVM.LLVMConstUIToFP
      */
-    public fun tofp(type: FloatType, signExtend: Boolean): ConstantFloat {
+    public fun getToFP(type: FloatType, signExtend: Boolean): ConstantFloat {
         val ref = if (signExtend) {
             LLVM.LLVMConstSIToFP(ref, type.ref)
         } else {
@@ -494,21 +495,21 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstUIToFP
      */
-    public fun uitofp(type: FloatType): ConstantFloat = tofp(type, false)
+    public fun getUIToFP(type: FloatType): ConstantFloat = getToFP(type, false)
 
     /**
      * Conversion to float type using this as signed
      *
      * @see LLVM.LLVMConstSIToFP
      */
-    public fun sitofp(type: FloatType): ConstantFloat = tofp(type, false)
+    public fun getSIToFP(type: FloatType): ConstantFloat = getToFP(type, false)
 
     /**
      * Conversion to integer pointer
      *
      * @see LLVM.LLVMConstIntToPtr
      */
-    public fun ptrcast(type: PointerType): ConstantPointer {
+    public fun getIntToPtr(type: PointerType): ConstantPointer {
         val ref = LLVM.LLVMConstIntToPtr(ref, type.ref)
 
         return ConstantPointer(ref)
@@ -521,7 +522,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstIntCast
      */
-    public fun intcast(type: IntType, signExtend: Boolean): ConstantInt {
+    public fun getIntCast(type: IntType, signExtend: Boolean): ConstantInt {
         val ref = LLVM.LLVMConstIntCast(ref, type.ref, signExtend.toLLVMBool())
 
         return ConstantInt(ref)
@@ -534,7 +535,7 @@ public class ConstantInt internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstSelect
      */
-    public fun select(ifTrue: Value, ifFalse: Value): Value {
+    public fun getSelect(ifTrue: Value, ifFalse: Value): Value {
         val ref = LLVM.LLVMConstSelect(ref, ifTrue.ref, ifFalse.ref)
 
         return Value(ref)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantPointer.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantPointer.kt
@@ -4,11 +4,12 @@ import dev.supergrecko.vexe.llvm.ir.Type
 import dev.supergrecko.vexe.llvm.ir.Value
 import dev.supergrecko.vexe.llvm.ir.types.IntType
 import dev.supergrecko.vexe.llvm.ir.types.PointerType
-import dev.supergrecko.vexe.llvm.ir.values.ConstantValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.ConstantValue
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ConstantPointer internal constructor() : Value(), ConstantValue {
+public class ConstantPointer internal constructor() : Value(),
+    ConstantValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef
     }
@@ -17,11 +18,9 @@ public class ConstantPointer internal constructor() : Value(), ConstantValue {
     /**
      * Conversion to integer
      *
-     * TODO: Assert that this points to an int
-     *
      * @see LLVM.LLVMConstPtrToInt
      */
-    public fun intcast(type: IntType): ConstantInt {
+    public fun getIntCast(type: IntType): ConstantInt {
         val ref = LLVM.LLVMConstPtrToInt(ref, type.ref)
 
         return ConstantInt(ref)
@@ -35,7 +34,7 @@ public class ConstantPointer internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstPointerCast
      */
-    fun cast(toType: Type): ConstantPointer {
+    fun getPointerCast(toType: Type): ConstantPointer {
         val value = LLVM.LLVMConstPointerCast(ref, toType.ref)
 
         return ConstantPointer(value)
@@ -48,7 +47,7 @@ public class ConstantPointer internal constructor() : Value(), ConstantValue {
      *
      * @see LLVM.LLVMConstAddrSpaceCast
      */
-    public fun addrspacecast(type: PointerType): ConstantPointer {
+    public fun getAddrSpaceCast(type: PointerType): ConstantPointer {
         val ref = LLVM.LLVMConstAddrSpaceCast(ref, type.ref)
 
         return ConstantPointer(ref)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantStruct.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantStruct.kt
@@ -4,15 +4,15 @@ import dev.supergrecko.vexe.llvm.internal.util.toLLVMBool
 import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Value
 import dev.supergrecko.vexe.llvm.ir.types.StructType
-import dev.supergrecko.vexe.llvm.ir.values.AggregateValue
-import dev.supergrecko.vexe.llvm.ir.values.CompositeValue
-import dev.supergrecko.vexe.llvm.ir.values.ConstantValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.AggregateValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.CompositeValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.ConstantValue
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ConstantStruct internal constructor() : Value(), ConstantValue,
-    AggregateValue, CompositeValue {
+public class ConstantStruct internal constructor() : Value(),
+    ConstantValue, AggregateValue, CompositeValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantVector.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantVector.kt
@@ -6,14 +6,14 @@ import dev.supergrecko.vexe.llvm.ir.IntPredicate
 import dev.supergrecko.vexe.llvm.ir.Value
 import dev.supergrecko.vexe.llvm.ir.types.FloatType
 import dev.supergrecko.vexe.llvm.ir.types.IntType
-import dev.supergrecko.vexe.llvm.ir.values.CompositeValue
-import dev.supergrecko.vexe.llvm.ir.values.ConstantValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.CompositeValue
+import dev.supergrecko.vexe.llvm.ir.values.traits.ConstantValue
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class ConstantVector internal constructor() : Value(), ConstantValue,
-    CompositeValue {
+public class ConstantVector internal constructor() : Value(),
+    ConstantValue, CompositeValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef
     }
@@ -44,7 +44,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * @see LLVM.LLVMConstNeg
      */
-    public fun neg(
+    public fun getNeg(
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
     ): ConstantVector {
@@ -62,12 +62,12 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
     /**
      * Invert each integer value using XOR
      *
-     * This in short performs the same action as [neg] but instead of using
+     * This in short performs the same action as [getNeg] but instead of using
      * subtraction it uses a bitwise XOR where B is always true.
      *
      * @see LLVM.LLVMConstNot
      */
-    public fun not(): ConstantVector {
+    public fun getNot(): ConstantVector {
         val ref = LLVM.LLVMConstNot(ref)
 
         return ConstantVector(ref)
@@ -86,7 +86,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * @see LLVM.LLVMConstAdd
      */
-    public fun add(
+    public fun getAdd(
         rhs: ConstantVector,
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
@@ -112,8 +112,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * respectively. If [hasNUW] [hasNSW] are present, the result
      * value of the add is a poison value if unsigned and/or signed overflow,
      * respectively, occurs.
+     *
+     * @see LLVM.LLVMConstSub
      */
-    public fun sub(
+    public fun getSub(
         rhs: ConstantVector,
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
@@ -139,8 +141,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * respectively. If [hasNUW] [hasNSW] are present, the result
      * value of the add is a poison value if unsigned and/or signed overflow,
      * respectively, occurs.
+     *
+     * @see LLVM.LLVMConstMul
      */
-    public fun mul(
+    public fun getMul(
         rhs: ConstantVector,
         hasNUW: Boolean = false,
         hasNSW: Boolean = false
@@ -169,9 +173,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * If the [exact] arg is present, the result value of the sdiv/udiv is a
      * poison value if the result would be rounded.
      *
-     * TODO: Find a way to determine if types is unsigned
+     * @see LLVM.LLVMConstUDiv
+     * @see LLVM.LLVMConstSDiv
      */
-    public fun div(
+    public fun getDiv(
         rhs: ConstantVector,
         exact: Boolean,
         unsigned: Boolean
@@ -197,11 +202,13 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * If the [exact] arg is present, the result value of the sdiv is a poison
      * value if the result would be rounded.
+     *
+     * @see LLVM.LLVMConstSDiv
      */
-    public fun sdiv(
+    public fun getSDiv(
         rhs: ConstantVector,
         exact: Boolean
-    ): ConstantVector = div(rhs, exact, false)
+    ): ConstantVector = getDiv(rhs, exact, false)
 
     /**
      * Perform division with another unsigned integer vector
@@ -212,11 +219,13 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * If the [exact] arg is present, the result value of the udiv is a poison
      * value if %op1 is not a multiple of %op2.
      * eg "((a udiv exact b) mul b) == a".
+     *
+     * @see LLVM.LLVMConstUDiv
      */
-    public fun udiv(
+    public fun getUDiv(
         rhs: ConstantVector,
         exact: Boolean
-    ): ConstantVector = div(rhs, exact, true)
+    ): ConstantVector = getDiv(rhs, exact, true)
 
     /**
      * Get the remainder from the unsigned division for the two operands
@@ -224,8 +233,11 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * Taking the remainder of a division by zero is undefined behavior.
      *
      * If [unsigned] is present, URem will be used
+     *
+     * @see LLVM.LLVMConstSRem
+     * @see LLVM.LLVMConstURem
      */
-    public fun rem(rhs: ConstantVector, unsigned: Boolean): ConstantVector {
+    public fun getRem(rhs: ConstantVector, unsigned: Boolean): ConstantVector {
         val ref = if (unsigned) {
             LLVM.LLVMConstURem(ref, rhs.ref)
         } else {
@@ -245,8 +257,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * 0	1	0
      * 1	0	0
      * 1	1	1
+     *
+     * @see LLVM.LLVMConstAnd
      */
-    public fun and(rhs: ConstantVector): ConstantVector {
+    public fun getAnd(rhs: ConstantVector): ConstantVector {
         val ref = LLVM.LLVMConstAnd(ref, rhs.ref)
 
         return ConstantVector(ref)
@@ -262,8 +276,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * 0	1	1
      * 1	0	1
      * 1	1	1
+     *
+     * @see LLVM.LLVMConstOr
      */
-    public fun or(rhs: ConstantVector): ConstantVector {
+    public fun getOr(rhs: ConstantVector): ConstantVector {
         val ref = LLVM.LLVMConstOr(ref, rhs.ref)
 
         return ConstantVector(ref)
@@ -279,8 +295,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * 0	1	1
      * 1	0	1
      * 1	1	0
+     *
+     * @see LLVM.LLVMConstXor
      */
-    public fun xor(rhs: ConstantVector): ConstantVector {
+    public fun getXor(rhs: ConstantVector): ConstantVector {
         val ref = LLVM.LLVMConstXor(ref, rhs.ref)
 
         return ConstantVector(ref)
@@ -291,8 +309,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * This method receives a [predicate] which determines which logical
      * comparison method shall be used for the comparison.
+     *
+     * @see LLVM.LLVMConstICmp
      */
-    public fun cmp(
+    public fun getICmp(
         predicate: IntPredicate,
         rhs: ConstantVector
     ): ConstantVector {
@@ -305,8 +325,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * Shift the operand to the left [rhs] number of bits
      *
      * LLVM-C does not support NUW/NSW attributes for this operation
+     *
+     * @see LLVM.LLVMConstShl
      */
-    public fun shl(rhs: ConstantVector): ConstantVector {
+    public fun getShl(rhs: ConstantVector): ConstantVector {
         val ref = LLVM.LLVMConstShl(ref, rhs.ref)
 
         return ConstantVector(ref)
@@ -317,8 +339,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * zero fill
      *
      * LLVM-C does not support NUW/NSW attributes for this operation
+     *
+     * @see LLVM.LLVMConstLShr
      */
-    public fun lshr(bits: ConstantVector): ConstantVector {
+    public fun getLShr(bits: ConstantVector): ConstantVector {
         val ref = LLVM.LLVMConstLShr(ref, bits.ref)
 
         return ConstantVector(ref)
@@ -329,8 +353,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * extension
      *
      * LLVM-C does nt support the 'exact' attribute for this operation
+     *
+     * @see LLVM.LLVMConstAShr
      */
-    public fun ashr(bits: ConstantVector): ConstantVector {
+    public fun getAShr(bits: ConstantVector): ConstantVector {
         val ref = LLVM.LLVMConstAShr(ref, bits.ref)
 
         return ConstantVector(ref)
@@ -341,8 +367,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * The bit size of this must be larger than the bit size of [type]. Equal
      * sizes are not allowed
+     *
+     * @see LLVM.LLVMConstTrunc
      */
-    public fun trunc(type: IntType): ConstantVector {
+    public fun getTrunc(type: IntType): ConstantVector {
         val ref = LLVM.LLVMConstTrunc(ref, type.ref)
 
         return ConstantVector(ref)
@@ -353,8 +381,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * The bit size of this must be tinier than the bit size of the
      * destination type
+     *
+     * @see LLVM.LLVMConstSExt
      */
-    public fun sext(type: IntType): ConstantVector {
+    public fun getSExt(type: IntType): ConstantVector {
         val ref = LLVM.LLVMConstSExt(ref, type.ref)
 
         return ConstantVector(ref)
@@ -365,8 +395,10 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * The bit size of this must be tinier than the bit size of the
      * destination type
+     *
+     * @see LLVM.LLVMConstZExt
      */
-    public fun zext(type: IntType): ConstantVector {
+    public fun getZExt(type: IntType): ConstantVector {
         val ref = LLVM.LLVMConstZExt(ref, type.ref)
 
         return ConstantVector(ref)
@@ -377,7 +409,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * @see LLVM.LLVMConstIntCast
      */
-    public fun intcast(type: IntType, signExtend: Boolean): ConstantVector {
+    public fun getIntCast(type: IntType, signExtend: Boolean): ConstantVector {
         val ref = LLVM.LLVMConstIntCast(ref, type.ref, signExtend.toLLVMBool())
 
         return ConstantVector(ref)
@@ -388,7 +420,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * @see LLVM.LLVMConstFPCast
      */
-    public fun fpcast(type: FloatType): ConstantVector {
+    public fun getFPCast(type: FloatType): ConstantVector {
         val ref = LLVM.LLVMConstFPCast(ref, type.ref)
 
         return ConstantVector(ref)
@@ -401,7 +433,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * @see LLVM.LLVMConstSelect
      */
-    public fun select(ifTrue: Value, ifFalse: Value): ConstantVector {
+    public fun getSelect(ifTrue: Value, ifFalse: Value): ConstantVector {
         val ref = LLVM.LLVMConstSelect(ref, ifTrue.ref, ifFalse.ref)
 
         return ConstantVector(ref)
@@ -412,7 +444,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * @see LLVM.LLVMConstExtractElement
      */
-    public fun extract(index: ConstantInt): Value {
+    public fun getExtractElement(index: ConstantInt): Value {
         val ref = LLVM.LLVMConstExtractElement(ref, index.ref)
 
         return Value(ref)
@@ -423,7 +455,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      *
      * The [value] must be of the same type as what this vector holds.
      */
-    public fun insert(index: ConstantInt, value: Value): ConstantVector {
+    public fun getInsertElement(index: ConstantInt, value: Value): ConstantVector {
         // LLVM has InsertElement(this, value, index) which is why args are
         // swapped
         val ref = LLVM.LLVMConstInsertElement(ref, value.ref, index.ref)
@@ -437,7 +469,7 @@ public class ConstantVector internal constructor() : Value(), ConstantValue,
      * This returns a vector with the same element type as the input length
      * that is the same as the shuffle mask.
      */
-    public fun shuffle(
+    public fun getShuffleVector(
         other: ConstantVector,
         mask: ConstantVector
     ): ConstantVector {

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/AggregateValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/AggregateValue.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.vexe.llvm.ir.values
+package dev.supergrecko.vexe.llvm.ir.values.traits
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import dev.supergrecko.vexe.llvm.ir.Value
@@ -18,7 +18,7 @@ public interface AggregateValue : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMConstGEP
      * @see LLVM.LLVMConstInBoundsGEP
      */
-    public fun gep(inbounds: Boolean, indices: List<ConstantInt>): Value {
+    public fun getGEP(inbounds: Boolean, indices: List<ConstantInt>): Value {
         val ptr = indices.map { it.ref }.toTypedArray()
 
         val ref = if (inbounds) {
@@ -44,7 +44,7 @@ public interface AggregateValue : ContainsReference<LLVMValueRef> {
      *
      * @see LLVM.LLVMConstExtractValue
      */
-    public fun extract(indices: List<Int>): Value {
+    public fun getExtractValue(indices: List<Int>): Value {
         val arr = indices.toTypedArray().toIntArray()
         val ref = LLVM.LLVMConstExtractValue(ref, arr, arr.size)
 
@@ -54,11 +54,11 @@ public interface AggregateValue : ContainsReference<LLVMValueRef> {
     /**
      * Insert the value into an aggregate value
      *
-     * This instruction uses the same navigation system as [extract]
+     * This instruction uses the same navigation system as [getExtractValue]
      *
      * @see LLVM.LLVMConstInsertValue
      */
-    public fun insert(value: Value, indices: List<Int>): Value {
+    public fun getInsertValue(value: Value, indices: List<Int>): Value {
         val arr = indices.toTypedArray().toIntArray()
         val ref = LLVM.LLVMConstInsertValue(ref, value.ref, arr, arr.size)
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/CompositeValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/CompositeValue.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.vexe.llvm.ir.values
+package dev.supergrecko.vexe.llvm.ir.values.traits
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import dev.supergrecko.vexe.llvm.ir.Value

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/ConstantValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/ConstantValue.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.vexe.llvm.ir.values
+package dev.supergrecko.vexe.llvm.ir.values.traits
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import dev.supergrecko.vexe.llvm.internal.contracts.Unreachable
@@ -44,7 +44,7 @@ public interface ConstantValue : ContainsReference<LLVMValueRef> {
      *
      * @see LLVM.LLVMConstBitCast
      */
-    public fun bitcast(type: Type): Value {
+    public fun getBitCast(type: Type): Value {
         val ref = LLVM.LLVMConstBitCast(ref, type.ref)
 
         return Value(ref)
@@ -61,7 +61,7 @@ public interface ConstantValue : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMConstSExtOrBitCast
      * @see LLVM.LLVMConstZExtOrBitCast
      */
-    public fun extOrBitcast(type: Type, signExtend: Boolean): Value {
+    public fun getExtOrBitCast(type: Type, signExtend: Boolean): Value {
         val ref = if (signExtend) {
             LLVM.LLVMConstSExtOrBitCast(ref, type.ref)
         } else {
@@ -76,8 +76,8 @@ public interface ConstantValue : ContainsReference<LLVMValueRef> {
      *
      * @see LLVM.LLVMConstZExtOrBitCast
      */
-    public fun zextOrBitcast(type: Type): Value {
-        return extOrBitcast(type, false)
+    public fun getZExtOrBitCast(type: Type): Value {
+        return getExtOrBitCast(type, false)
     }
 
     /**
@@ -85,8 +85,8 @@ public interface ConstantValue : ContainsReference<LLVMValueRef> {
      *
      * @see LLVM.LLVMConstSExtOrBitCast
      */
-    public fun sextOrBitcast(type: Type): Value {
-        return extOrBitcast(type, true)
+    public fun getSExtOrBitCast(type: Type): Value {
+        return getExtOrBitCast(type, true)
     }
 
     /**
@@ -96,7 +96,7 @@ public interface ConstantValue : ContainsReference<LLVMValueRef> {
      *
      * @see LLVM.LLVMConstTruncOrBitCast
      */
-    public fun truncOrBitcast(type: Type): Value {
+    public fun getTruncOrBitCast(type: Type): Value {
         val ref = LLVM.LLVMConstTruncOrBitCast(ref, type.ref)
 
         return Value(ref)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/DebugLocationValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/DebugLocationValue.kt
@@ -1,4 +1,4 @@
-package dev.supergrecko.vexe.llvm.ir.values
+package dev.supergrecko.vexe.llvm.ir.values.traits
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import org.bytedeco.javacpp.IntPointer

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/values/ConstantTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/values/ConstantTest.kt
@@ -12,8 +12,8 @@ internal class ConstantTest : TestSuite({
         val ptrTy = PointerType(type)
         val value = ConstantInt(type, 1L, true)
 
-        val ptr = value.ptrcast(ptrTy.toPointerType())
-        val res = ptr.cast(type)
+        val ptr = value.getIntToPtr(ptrTy.toPointerType())
+        val res = ptr.getPointerCast(type)
 
         assertEquals(1L, ConstantInt(res.ref).getSignedValue())
     }

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/values/constants/ConstantIntTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/values/constants/ConstantIntTest.kt
@@ -25,7 +25,7 @@ internal class ConstantIntTest : TestSuite({
         val ty = IntType(32)
         val v = ConstantInt(ty, 100)
 
-        val neg = v.neg()
+        val neg = v.getNeg()
 
         assertEquals(-100L, neg.getSignedValue())
     }
@@ -34,7 +34,7 @@ internal class ConstantIntTest : TestSuite({
         val ty = IntType(32)
         val v = ConstantInt(ty, 100)
 
-        val not = v.not()
+        val not = v.getNot()
 
         assertEquals(-101, not.getSignedValue())
     }
@@ -45,7 +45,7 @@ internal class ConstantIntTest : TestSuite({
         val v1 = ConstantInt(ty, 100)
         val v2 = ConstantInt(ty, 300)
 
-        val sum = v1.add(v2)
+        val sum = v1.getAdd(v2)
 
         assertEquals(400, sum.getSignedValue())
         assertEquals(400, sum.getUnsignedValue())
@@ -57,7 +57,7 @@ internal class ConstantIntTest : TestSuite({
         val v1 = ConstantInt(ty, 400)
         val v2 = ConstantInt(ty, 200)
 
-        val diff = v1.sub(v2)
+        val diff = v1.getSub(v2)
 
         assertEquals(200, diff.getSignedValue())
         assertEquals(200, diff.getUnsignedValue())
@@ -69,7 +69,7 @@ internal class ConstantIntTest : TestSuite({
         val v1 = ConstantInt(ty, 100)
         val v2 = ConstantInt(ty, 10)
 
-        val product = v1.mul(v2)
+        val product = v1.getMul(v2)
 
         assertEquals(1000, product.getSignedValue())
         assertEquals(1000, product.getUnsignedValue())
@@ -81,10 +81,10 @@ internal class ConstantIntTest : TestSuite({
         val v1 = ConstantInt(ty, 100, false)
         val v2 = ConstantInt(ty, 10, false)
 
-        val quotient1 = v1.sdiv(v2, exact = true)
-        val quotient2 = v1.sdiv(v2, exact = false)
-        val quotient3 = v1.udiv(v2, exact = true)
-        val quotient4 = v1.udiv(v2, exact = false)
+        val quotient1 = v1.getSDiv(v2, exact = true)
+        val quotient2 = v1.getSDiv(v2, exact = false)
+        val quotient3 = v1.getUDiv(v2, exact = true)
+        val quotient4 = v1.getUDiv(v2, exact = false)
 
         assertEquals(10, quotient1.getSignedValue())
         assertEquals(10, quotient2.getSignedValue())
@@ -99,10 +99,10 @@ internal class ConstantIntTest : TestSuite({
         val v1 = ConstantInt(ty, 10, false)
         val v2 = ConstantInt(ty, 3, false)
 
-        val quotient1 = v1.sdiv(v2, exact = true)
-        val quotient2 = v1.sdiv(v2, exact = false)
-        val quotient3 = v1.udiv(v2, exact = true)
-        val quotient4 = v1.udiv(v2, exact = false)
+        val quotient1 = v1.getSDiv(v2, exact = true)
+        val quotient2 = v1.getSDiv(v2, exact = false)
+        val quotient3 = v1.getUDiv(v2, exact = true)
+        val quotient4 = v1.getUDiv(v2, exact = false)
 
         assertEquals(3, quotient1.getSignedValue())
         assertEquals(3, quotient2.getSignedValue())
@@ -116,8 +116,8 @@ internal class ConstantIntTest : TestSuite({
         val v1 = ConstantInt(ty, 10, false)
         val v2 = ConstantInt(ty, 3, false)
 
-        val rem1 = v1.urem(v2)
-        val rem2 = v1.srem(v2)
+        val rem1 = v1.getURem(v2)
+        val rem2 = v1.getSRem(v2)
 
         assertEquals(1, rem1.getUnsignedValue())
         assertEquals(1, rem1.getSignedValue())
@@ -128,7 +128,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Bitwise logical and") {
         val (lhs, rhs) = constIntPairOf(2, 6)
 
-        val res = lhs.and(rhs).getSignedValue()
+        val res = lhs.getAnd(rhs).getSignedValue()
 
         assertEquals(2 and 6, res)
     }
@@ -136,7 +136,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Bitwise logical or") {
         val (lhs, rhs) = constIntPairOf(16, 92)
 
-        val res = lhs.or(rhs).getSignedValue()
+        val res = lhs.getOr(rhs).getSignedValue()
 
         assertEquals(16 or 92, res)
     }
@@ -144,7 +144,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Bitwise logical xor") {
         val (lhs, rhs) = constIntPairOf(100, 200)
 
-        val res = lhs.xor(rhs).getSignedValue()
+        val res = lhs.getXor(rhs).getSignedValue()
 
         assertEquals(100 xor 200, res)
     }
@@ -161,7 +161,7 @@ internal class ConstantIntTest : TestSuite({
         )
 
         runAll(*IntPredicate.values()) { it, idx ->
-            val res = lhs.cmp(it, rhs).getUnsignedValue()
+            val res = lhs.getICmp(it, rhs).getUnsignedValue()
 
             val expect = expected[idx]
 
@@ -172,7 +172,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Bitwise left shift") {
         val (lhs, rhs) = constIntPairOf(10, 20)
 
-        val res = lhs.shl(rhs).getSignedValue()
+        val res = lhs.getShl(rhs).getSignedValue()
 
         assertEquals(10 shl 20, res)
     }
@@ -180,7 +180,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Bitwise right shift") {
         val (lhs, rhs) = constIntPairOf(10, 20)
 
-        val res = lhs.lshr(rhs).getSignedValue()
+        val res = lhs.getLShr(rhs).getSignedValue()
 
         assertEquals(10 shr 20, res)
     }
@@ -188,7 +188,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Bitwise arithmetic right shift") {
         val (lhs, rhs) = constIntPairOf(10, 20)
 
-        val res = lhs.ashr(rhs).getSignedValue()
+        val res = lhs.getAShr(rhs).getSignedValue()
 
         assertEquals(10 shr 20, res)
     }
@@ -196,7 +196,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Truncation to tinier type") {
         val lhs = ConstantInt(IntType(8), 64)
 
-        val trunc = lhs.trunc(IntType(1))
+        val trunc = lhs.getTrunc(IntType(1))
 
         assertEquals(0, trunc.getUnsignedValue())
     }
@@ -204,8 +204,8 @@ internal class ConstantIntTest : TestSuite({
     describe("Zero or sign-extend the type") {
         val lhs = ConstantInt(IntType(8), 64)
 
-        val sext = lhs.sext(IntType(16))
-        val zext = lhs.zext(IntType(16))
+        val sext = lhs.getSExt(IntType(16))
+        val zext = lhs.getZExt(IntType(16))
 
         assertEquals(64, sext.getSignedValue())
         assertEquals(64, zext.getUnsignedValue())
@@ -214,8 +214,8 @@ internal class ConstantIntTest : TestSuite({
     describe("Cast to float type") {
         val lhs = ConstantInt(IntType(64), 64)
 
-        val si = lhs.sitofp(FloatType(TypeKind.Float))
-        val ui = lhs.uitofp(FloatType(TypeKind.Double))
+        val si = lhs.getSIToFP(FloatType(TypeKind.Float))
+        val ui = lhs.getUIToFP(FloatType(TypeKind.Double))
 
         assertEquals(64.0, si.getDouble())
         assertEquals(64.0, ui.getDouble())
@@ -226,11 +226,11 @@ internal class ConstantIntTest : TestSuite({
     describe("Cast to pointer type") {
         val ty = IntType(64)
         val lhs = ConstantInt(ty, 100)
-        val ptr = lhs.ptrcast(PointerType(ty))
+        val ptr = lhs.getIntToPtr(PointerType(ty))
 
         assertTrue { ptr.isConstant() }
 
-        val num = ptr.intcast(ty)
+        val num = ptr.getIntCast(ty)
 
         assertEquals(lhs.getSignedValue(), num.getSignedValue())
     }
@@ -239,7 +239,7 @@ internal class ConstantIntTest : TestSuite({
         val targetTy = IntType(128)
         val lhs = ConstantInt(IntType(32), 100000)
 
-        val second = lhs.intcast(targetTy, true)
+        val second = lhs.getIntCast(targetTy, true)
 
         assertEquals(lhs.getSignedValue(), second.getSignedValue())
     }
@@ -247,7 +247,7 @@ internal class ConstantIntTest : TestSuite({
     describe("Cast to own type does nothing") {
         val lhs = ConstantInt(IntType(32), 100000)
 
-        lhs.intcast(IntType(32), true)
+        lhs.getIntCast(IntType(32), true)
     }
 
     describe("Perform conditional select instruction") {
@@ -256,7 +256,7 @@ internal class ConstantIntTest : TestSuite({
 
         val (lhs, rhs) = constIntPairOf(10, 20)
 
-        val res = cond.select(lhs, rhs)
+        val res = cond.getSelect(lhs, rhs)
 
         assertEquals(10, ConstantInt(res.ref).getSignedValue())
     }


### PR DESCRIPTION
The ConstantAPIs had inconsistent names such as ```kotlin
fun cmp(...)
```

These have been renamed to `getCmp` to fit into the rest of the functions the wrapper provides.