### PR TITLE
[api] Implement QOL changes for Callback APIs

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateCodeSectionCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateCodeSectionCallback.kt
@@ -6,12 +6,16 @@ import org.bytedeco.javacpp.Pointer
 import org.bytedeco.llvm.LLVM.LLVMMemoryManagerAllocateCodeSectionCallback
 
 public typealias MemoryManagerAllocateCodeSectionCallback = (
-    Pointer?,
-    Long,
-    Int,
-    Int,
-    BytePointer?
+    MemoryManagerAllocateCodeSectionCallbackContext
 ) -> BytePointer
+
+public data class MemoryManagerAllocateCodeSectionCallbackContext(
+    public val payload: Pointer?,
+    public val size: Long,
+    public val alignment: Int,
+    public val sectionId: Int,
+    public val sectionName: String
+)
 
 public class MemoryManagerAllocateCodeSectionBase(
     private val callback: MemoryManagerAllocateCodeSectionCallback
@@ -23,6 +27,14 @@ public class MemoryManagerAllocateCodeSectionBase(
         arg3: Int,
         arg4: BytePointer?
     ): BytePointer {
-        return callback.invoke(arg0, arg1, arg2, arg3, arg4)
+        val data = MemoryManagerAllocateCodeSectionCallbackContext(
+            payload = arg0,
+            size = arg1,
+            alignment = arg2,
+            sectionId = arg3,
+            sectionName = arg4?.string ?: ""
+        )
+
+        return callback.invoke(data)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateDataSectionCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerAllocateDataSectionCallback.kt
@@ -7,13 +7,17 @@ import org.bytedeco.javacpp.Pointer
 import org.bytedeco.llvm.LLVM.LLVMMemoryManagerAllocateDataSectionCallback
 
 public typealias MemoryManagerAllocateDataSectionCallback = (
-    Pointer?,
-    Long,
-    Int,
-    Int,
-    BytePointer?,
-    Boolean
+    MemoryManagerAllocateDataSectionCallbackContext
 ) -> BytePointer
+
+public data class MemoryManagerAllocateDataSectionCallbackContext(
+    public val payload: Pointer?,
+    public val size: Long,
+    public val alignment: Int,
+    public val sectionId: Int,
+    public val sectionName: String,
+    public val isReadOnly: Boolean
+)
 
 public class MemoryManagerAllocateDataSectionBase(
     private val callback: MemoryManagerAllocateDataSectionCallback
@@ -26,8 +30,15 @@ public class MemoryManagerAllocateDataSectionBase(
         arg4: BytePointer?,
         arg5: Int
     ): BytePointer {
-        val bool = arg5.fromLLVMBool()
+        val data = MemoryManagerAllocateDataSectionCallbackContext(
+            payload = arg0,
+            size = arg1,
+            alignment = arg2,
+            sectionId = arg3,
+            sectionName = arg4?.string ?: "",
+            isReadOnly = arg5.fromLLVMBool()
+        )
 
-        return callback.invoke(arg0, arg1, arg2, arg3, arg4, bool)
+        return callback.invoke(data)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerDestroyCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerDestroyCallback.kt
@@ -5,13 +5,21 @@ import org.bytedeco.javacpp.Pointer
 import org.bytedeco.llvm.LLVM.LLVMMemoryManagerDestroyCallback
 
 public typealias MemoryManagerDestroyCallback = (
-    Pointer?
+    MemoryManagerDestroyCallbackContext
 ) -> Unit
+
+public data class MemoryManagerDestroyCallbackContext(
+    public val payload: Pointer?
+)
 
 public class MemoryManagerDestroyBase(
     private val callback: MemoryManagerDestroyCallback
 ) : LLVMMemoryManagerDestroyCallback(), Callback {
     public override fun call(arg0: Pointer?) {
-        callback.invoke(arg0)
+        val data = MemoryManagerDestroyCallbackContext(
+            payload = arg0
+        )
+
+        callback.invoke(data)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerFinalizeMemoryCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/executionengine/callbacks/MemoryManagerFinalizeMemoryCallback.kt
@@ -6,16 +6,23 @@ import org.bytedeco.javacpp.Pointer
 import org.bytedeco.llvm.LLVM.LLVMMemoryManagerFinalizeMemoryCallback
 
 public typealias MemoryManagerFinalizeMemoryCallback = (
-    Pointer?,
-    String?
+    MemoryManagerFinalizeMemoryCallbackContext
 ) -> Int
+
+public data class MemoryManagerFinalizeMemoryCallbackContext(
+    public val payload: Pointer?,
+    public val error: String
+)
 
 public class MemoryManagerFinalizeMemoryBase(
     private val callback: MemoryManagerFinalizeMemoryCallback
 ) : LLVMMemoryManagerFinalizeMemoryCallback(), Callback {
     public override fun call(arg0: Pointer?, arg1: BytePointer?): Int {
-        val msg = arg1?.string
+        val data = MemoryManagerFinalizeMemoryCallbackContext(
+            payload = arg0,
+            error = arg1?.string ?: ""
+        )
 
-        return callback.invoke(arg0, msg)
+        return callback.invoke(data)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Context.kt
@@ -47,8 +47,8 @@ public class Context public constructor(
      * @see LLVM.LLVMContextSetDiagnosticHandler
      */
     public fun setDiagnosticHandler(
-        handler: DiagnosticHandlerCallback,
-        payload: Pointer? = null
+        payload: Pointer? = null,
+        handler: DiagnosticHandlerCallback
     ) {
         val handlePtr = DiagnosticHandlerBase(handler)
 
@@ -82,8 +82,8 @@ public class Context public constructor(
      * @see LLVM.LLVMContextSetYieldCallback
      */
     public fun setYieldCallback(
-        callback: YieldCallback,
-        payload: Pointer? = null
+        payload: Pointer? = null,
+        callback: YieldCallback
     ) {
         val handlePtr = YieldCallbackBase(callback)
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/DiagnosticHandlerCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/DiagnosticHandlerCallback.kt
@@ -1,7 +1,6 @@
 package dev.supergrecko.vexe.llvm.ir.callbacks
 
 import dev.supergrecko.vexe.llvm.internal.contracts.Callback
-import dev.supergrecko.vexe.llvm.internal.util.wrap
 import dev.supergrecko.vexe.llvm.ir.DiagnosticInfo
 import org.bytedeco.javacpp.Pointer
 import org.bytedeco.llvm.LLVM.LLVMDiagnosticHandler
@@ -14,14 +13,24 @@ import org.bytedeco.llvm.LLVM.LLVMDiagnosticInfoRef
  * [DiagnosticInfo] The associated DiagnosticInfo reporter
  * [Pointer] The payload which was sent with the setter for this callback
  */
-public typealias DiagnosticHandlerCallback = (DiagnosticInfo?, Pointer?) -> Unit
+public typealias DiagnosticHandlerCallback = (
+    DiagnosticHandlerCallbackContext
+) -> Unit
+
+public data class DiagnosticHandlerCallbackContext(
+    public val diagnostic: DiagnosticInfo,
+    public val payload: Pointer?
+)
 
 public class DiagnosticHandlerBase(
     private val callback: DiagnosticHandlerCallback
 ) : LLVMDiagnosticHandler(), Callback {
-    public override fun call(arg0: LLVMDiagnosticInfoRef?, arg1: Pointer?) {
-        val di = wrap(arg0) { DiagnosticInfo(it) }
+    public override fun call(arg0: LLVMDiagnosticInfoRef, arg1: Pointer?) {
+        val data = DiagnosticHandlerCallbackContext(
+            diagnostic = DiagnosticInfo(arg0),
+            payload = arg1
+        )
 
-        callback.invoke(di, arg1)
+        callback.invoke(data)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/YieldCallback.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/callbacks/YieldCallback.kt
@@ -15,14 +15,22 @@ import org.bytedeco.llvm.LLVM.LLVMYieldCallback
  * [Context] The context this was set to
  * [Pointer] The payload which was sent with the setter for this callback
  */
-public typealias YieldCallback = (Context?, Pointer?) -> Unit
+public typealias YieldCallback = (YieldCallbackContext) -> Unit
+
+public data class YieldCallbackContext(
+    public val context: Context,
+    public val payload: Pointer?
+)
 
 public class YieldCallbackBase(
     private val callback: YieldCallback
 ) : LLVMYieldCallback(), Callback {
-    public override fun call(arg0: LLVMContextRef?, arg1: Pointer?) {
-        val ctx = wrap(arg0) { Context(it) }
+    public override fun call(arg0: LLVMContextRef, arg1: Pointer?) {
+        val data = YieldCallbackContext(
+            context = Context(arg0),
+            payload = arg1
+        )
 
-        callback.invoke(ctx, arg1)
+        callback.invoke(data)
     }
 }

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/CallbackTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/CallbackTest.kt
@@ -8,8 +8,7 @@ internal class CallbackTest : TestSuite({
     describe("Creating a callback") {
         val ctx = Context().apply {
             // Kotlin lambdas!
-            setDiagnosticHandler({ _, _ ->
-            })
+            setDiagnosticHandler {}
         }
 
         cleanup(ctx)


### PR DESCRIPTION
The initial implementation of the Callback APIs had the payload argument ordered after the block, this led to unnecessary parentheses when no payload was being sent. The callback block itself had to explicitly ignore or accept the arguments, see example:

```kotlin
// Explicit parentheses for no payload, explicit ignored arguments
context.setDiagnosticHandler({ _, _ -> 

})
```

This PR changes this by reordering the argument order, allowing the parentheses to be omitted as well as passing a single argument, a context specific to that callback with the arguments. Previously the arguments in the callback function had no names so it was not possible to tell what argument is which right away.

Passing a data class as the only argument to the callback solves both of these problems.

The new API now looks like this:

```kotlin
context.setDiagnosticHandler {
  // Access props from it
  println(it.diagnostic)
}
```

