### PR TITLE
[api] Make Entries wrappers contain a size

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
@@ -74,7 +74,7 @@ public open class Instruction internal constructor() : Value(),
             size
         )
 
-        return MetadataEntries(entries)
+        return MetadataEntries(entries, size)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/MetadataEntries.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/MetadataEntries.kt
@@ -2,24 +2,30 @@ package dev.supergrecko.vexe.llvm.ir
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import dev.supergrecko.vexe.llvm.internal.contracts.Disposable
+import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMMetadataRef
 import org.bytedeco.llvm.LLVM.LLVMValueMetadataEntry
 import org.bytedeco.llvm.global.LLVM
 
-/**
- * Class wrapping [LLVMValueMetadataEntry]
- *
- * LLVM uses this as an array of [LLVMMetadataRef]s and thus I feel like it
- * should be named Entries as that is what it used for.
- */
 public class MetadataEntries internal constructor() :
     ContainsReference<LLVMValueMetadataEntry>, Disposable {
+    internal lateinit var sizePtr: SizeTPointer
     public override var valid: Boolean = true
     public override lateinit var ref: LLVMValueMetadataEntry
         internal set
 
-    public constructor(llvmRef: LLVMValueMetadataEntry) : this() {
+    public constructor(
+        llvmRef: LLVMValueMetadataEntry,
+        size: SizeTPointer
+    ) : this() {
         ref = llvmRef
+        sizePtr = size
+
+        assert(sizePtr.capacity() > 0)
+    }
+
+    public fun size(): Long {
+        return sizePtr.get()
     }
 
     //region Core::Metadata

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/MetadataEntries.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/MetadataEntries.kt
@@ -35,6 +35,12 @@ public class MetadataEntries internal constructor() :
      * @see LLVM.LLVMValueMetadataEntriesGetKind
      */
     public fun getKind(index: Int): Int {
+        if (index >= size()) {
+            throw IndexOutOfBoundsException(
+                "Index $index out of bounds for size of ${size()}"
+            )
+        }
+
         return LLVM.LLVMValueMetadataEntriesGetKind(ref, index)
     }
 
@@ -44,8 +50,12 @@ public class MetadataEntries internal constructor() :
      * @see LLVM.LLVMValueMetadataEntriesGetMetadata
      */
     public fun getMetadata(index: Int): Metadata {
-        // TODO: longterm: prevent segfault by out of bounds index via size_t
-        //  ptr?
+        if (index >= size()) {
+            throw IndexOutOfBoundsException(
+                "Index $index out of bounds for size of ${size()}"
+            )
+        }
+
         val metadata = LLVM.LLVMValueMetadataEntriesGetMetadata(ref, index)
 
         return Metadata(metadata)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -153,7 +153,7 @@ public class Module internal constructor() : Disposable,
         val size = SizeTPointer(0)
         val entries = LLVM.LLVMCopyModuleFlagsMetadata(ref, size)
 
-        return ModuleFlagEntries(entries)
+        return ModuleFlagEntries(entries, size)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
@@ -15,12 +15,23 @@ import org.bytedeco.llvm.global.LLVM
  */
 public class ModuleFlagEntries internal constructor() :
     ContainsReference<LLVMModuleFlagEntry>, Disposable {
+    internal lateinit var sizePtr: SizeTPointer
     public override var valid: Boolean = true
     public override lateinit var ref: LLVMModuleFlagEntry
         internal set
 
-    public constructor(llvmRef: LLVMModuleFlagEntry) : this() {
+    public constructor(
+        llvmRef: LLVMModuleFlagEntry,
+        size: SizeTPointer
+    ) : this() {
         ref = llvmRef
+        sizePtr = size
+
+        assert(sizePtr.capacity() > 0)
+    }
+
+    fun size(): Long {
+        return sizePtr.get()
     }
 
     //region Core::Modules

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
@@ -38,11 +38,15 @@ public class ModuleFlagEntries internal constructor() :
     /**
      * Get the [ModuleFlagBehavior] for the entry at [index]
      *
-     * TODO: What happens with out of bounds index?
-     *
      * @see LLVM.LLVMModuleFlagEntriesGetFlagBehavior
      */
     public fun getBehavior(index: Int): ModuleFlagBehavior {
+        if (index >= size()) {
+            throw IndexOutOfBoundsException(
+                "Index $index out of bounds for size of ${size()}"
+            )
+        }
+
         val behavior = LLVM.LLVMModuleFlagEntriesGetFlagBehavior(ref, index)
 
         return ModuleFlagBehavior.values()
@@ -52,11 +56,15 @@ public class ModuleFlagEntries internal constructor() :
     /**
      * Get the key for the entry at [index]
      *
-     * TODO: What happens with out of bounds index?
-     *
      * @see LLVM.LLVMModuleFlagEntriesGetKey
      */
     public fun getKey(index: Int): String {
+        if (index >= size()) {
+            throw IndexOutOfBoundsException(
+                "Index $index out of bounds for size of ${size()}"
+            )
+        }
+
         val length = SizeTPointer(0)
 
         return LLVM.LLVMModuleFlagEntriesGetKey(ref, index, length).string
@@ -65,11 +73,15 @@ public class ModuleFlagEntries internal constructor() :
     /**
      * Get the [Metadata] for the entry at [index]
      *
-     * TODO: What happens with out of bounds index?
-     *
      * @see LLVM.LLVMModuleFlagEntriesGetMetadata
      */
     public fun getMetadata(index: Int): Metadata {
+        if (index >= size()) {
+            throw IndexOutOfBoundsException(
+                "Index $index out of bounds for size of ${size()}"
+            )
+        }
+
         val md = LLVM.LLVMModuleFlagEntriesGetMetadata(ref, index)
 
         return Metadata(md)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalValue.kt
@@ -233,7 +233,7 @@ public open class GlobalValue internal constructor() : Value(),
 
         val entries = LLVM.LLVMGlobalCopyAllMetadata(ref, ptr)
 
-        return MetadataEntries(entries)
+        return MetadataEntries(entries, ptr)
     }
     //endregion Core::Values::Constants::GlobalValues
 }


### PR DESCRIPTION
Previously there was no way of telling how large a MetadataEntries or ModuleFlagEntries were even though this information was available through the LLVM API in the form of a `size_t*`.

This PR passes this pointer to these classes so we can retrieve the size of the collection.

We are now able to determine if any accessing indexes are out of bounds before calling the LLVM with invalid data.