### PR TITLE
[tests] Update tests for Modules

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -202,7 +202,7 @@ public class Module internal constructor() : Disposable,
 
         val result = LLVM.LLVMPrintModuleToFile(ref, fileName, message)
 
-        return if (result == 0) {
+        return if (result != 0) {
             Message(message)
         } else {
             null
@@ -549,7 +549,7 @@ public class Module internal constructor() : Disposable,
      * @see LLVM.LLVMVerifyModule
      */
     public fun verify(action: VerifierFailureAction): Boolean {
-        val ptr = BytePointer(ByteBuffer.allocate(0))
+        val ptr = BytePointer(0L)
 
         val res = LLVM.LLVMVerifyModule(ref, action.value, ptr)
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
@@ -26,8 +26,6 @@ public class ModuleFlagEntries internal constructor() :
     ) : this() {
         ref = llvmRef
         sizePtr = size
-
-        assert(sizePtr.capacity() > 0)
     }
 
     fun size(): Long {

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
@@ -1,19 +1,21 @@
 package dev.supergrecko.vexe.llvm.unit.ir
 
+import dev.supergrecko.vexe.llvm.TestUtils
 import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Metadata
 import dev.supergrecko.vexe.llvm.ir.Module
 import dev.supergrecko.vexe.llvm.ir.ModuleFlagBehavior
-import dev.supergrecko.vexe.llvm.ir.types.FunctionType
 import dev.supergrecko.vexe.llvm.ir.types.IntType
 import dev.supergrecko.vexe.llvm.ir.types.StructType
 import dev.supergrecko.vexe.llvm.ir.types.VoidType
+import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
 import dev.supergrecko.vexe.llvm.setup
 import dev.supergrecko.vexe.llvm.support.VerifierFailureAction
-import dev.supergrecko.vexe.llvm.utils.cleanup
-import dev.supergrecko.vexe.test.TestSuite
 import org.spekframework.spek2.Spek
+import java.nio.file.Files
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -22,6 +24,7 @@ internal object ModuleTest : Spek({
     setup()
 
     val module: Module by memoized()
+    val utils: TestUtils by memoized()
 
     group("module source file names") {
         test("assigning a module identifier") {
@@ -103,164 +106,81 @@ internal object ModuleTest : Spek({
 
             val subject = module.getModuleFlags()
 
+            assertEquals(1, subject.size())
             assertEquals(ModuleFlagBehavior.Override, subject.getBehavior(0))
         }
+
+        test("retrieving out of bounds will fail") {
+            val subject = module.getModuleFlags()
+
+            assertEquals(0, subject.size())
+            assertFailsWith<IndexOutOfBoundsException> {
+                subject.getKey(1)
+            }
+        }
     }
-})
 
-internal class ModuleTest2 : TestSuite({
-    describe("Fetching a function which does not exist returns null") {
-        val module = Module("utils.ll")
+    group("dumping the ir representation of the module") {
+        test("printing to string") {
+            val str = module.toString()
 
-        assertNull(module.getFunction("utils"))
-
-        cleanup(module)
-    }
-
-    describe("Fetching an existing function returns said function") {
-        val module = Module("utils.ll").apply {
-            addFunction(
-                "utils",
-                FunctionType(
-                    VoidType(),
-                    listOf(),
-                    false
-                )
-            )
-
-            assertNotNull(getFunction("utils"))
+            assertTrue { str.isNotEmpty() }
         }
 
-        cleanup(module)
-    }
+        test("printing to file") {
+            val file = utils.getTemporaryFile()
+            val message = module.toFile(file.absolutePath)
+            val content = Files.readAllLines(file.toPath())
+                .joinToString("")
 
-    describe("Write the module byte-code to file") {
-        val file = getTemporaryFile("out.bc")
-        val module = Module("utils.ll").also {
-            it.writeBitCodeToFile(file)
+            assertNull(message)
+            assertTrue { content.isNotEmpty() }
         }
-
-        assertTrue { file.length() > 0 }
-
-        cleanup(module)
     }
 
-    describe("Write the module byte-code to file path") {
-        val file = getTemporaryFile("out.bc")
-        val module = Module("utils.ll").also {
-            it.writeBitCodeToFile(file.absolutePath)
-        }
-
-        assertTrue { file.exists() }
-
-        cleanup(module)
-    }
-
-    describe("Writing to MemoryBuffer") {
-        val context = Context()
-        val module = Module("utils.ll", context)
-
-        val buf = module.toMemoryBuffer()
-
-        assertNotNull(buf.ref)
-
-        cleanup(module, context)
-    }
-
-    describe("Get module from MemoryBuffer") {
-        val context = Context()
-        val module = Module("utils.ll", context)
-        val buf = module.toMemoryBuffer()
-        val mod = buf.getModule(context)
-
-        assertEquals("utils.ll", mod.getSourceFileName())
-
-        cleanup(mod, module, context)
-    }
-
-    describe("Verification of a valid module") {
-        val context = Context()
-        val module = Module("utils.ll", context)
-        val res = module.verify(VerifierFailureAction.ReturnStatus)
-
-        assertEquals(true, res)
-
-        cleanup(module, context)
-    }
-
-    describe("Creation of function inside module") {
-        val fnTy = FunctionType(IntType(32), listOf(), false)
-        val module = Module("utils.ll")
-        val fn = module.addFunction("utils", fnTy)
-
-        assertEquals(0, fn.getParameterCount())
-
-        cleanup(module)
-    }
-
-    describe("Assigning a data layout") {
-        val module = Module("utils.ll").apply {
-            setDataLayout("e-m:e-i64:64-f80:128-n8:16:32:64-S128")
-        }
-
-        assertEquals(
-            "e-m:e-i64:64-f80:128-n8:16:32:64-S128", module.getDataLayout()
-        )
-
-        cleanup(module)
-    }
-
-    describe("Assigning a target triple") {
-        val module = Module("utils.ll").apply {
-            setTarget("x86_64-pc-linux")
-        }
-
-        assertEquals("x86_64-pc-linux", module.getTarget())
-
-        cleanup(module)
-    }
-
-    describe("Retrieving LLVM IR") {
-        val module = Module("utils.ll")
-        val ir = module.toString()
-
-        assertTrue { ir.isNotEmpty() }
-
-        cleanup(module)
-    }
-
-    describe("Setting module inline assembly") {
-        val module = Module("utils.ll").apply {
+    test("using inline assembler instructions") {
+        module.apply {
             setInlineAssembly(".example")
             appendInlineAssembly("    push 0")
             appendInlineAssembly("    ret")
         }
-        val result = ".example\n    push 0\n    ret\n"
 
-        // LLVM Appends a new line after any inline-asm changes
-        assertEquals(result, module.getInlineAssembly())
+        val expected = ".example\n    push 0\n    ret\n"
 
-        cleanup(module)
+        assertEquals(expected, module.getInlineAssembly())
     }
 
-    describe("Retrieving Context from Module") {
-        val ctx = Context()
-        val module = Module("utils.ll", ctx)
+    test("retrieving the context of the module") {
+        // Our Spek memoized value uses the global Context
+        val ctx = module.getContext()
+        val global = Context.getGlobalContext()
 
-        assertEquals(ctx.ref, module.getContext().ref)
-
-        cleanup(module, ctx)
+        assertEquals(global.ref, ctx.ref)
     }
 
-    describe("Retrieving a type from a module") {
-        val ctx = Context()
-        val type = StructType("TestStruct", ctx)
-        val module = Module("utils.ll", ctx)
-        val found = module.getTypeByName("TestStruct")
+    test("finding types inside a module") {
+        // Both uses global Context
+        val type = StructType("EmptyType")
+        val subject = module.getTypeByName("EmptyType")
 
-        assertNotNull(found)
-        assertEquals(type.ref, found.ref)
+        assertEquals(type.ref, subject?.ref)
+    }
 
-        cleanup(module, ctx)
+    group("verification") {
+        test("verification of a valid module") {
+            val success = module.verify(VerifierFailureAction.PrintMessage)
+
+            assertTrue { success }
+        }
+
+        test("invalid module") {
+            module.addGlobal("Nothing", VoidType()).apply {
+                setInitializer(ConstantInt(IntType(32), 100))
+            }
+
+            val success = module.verify(VerifierFailureAction.ReturnStatus)
+
+            assertFalse { success }
+        }
     }
 })


### PR DESCRIPTION
This adds missing test cases to the LLVM Modules as well as converting to Spek.

The parts of the Module.kt file which are untested are not directly related to the Module itself. These tests will be located where the most relevant feature is located.