### PR TITLE
[api] Create custom type for LLVM IR

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/IR.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/IR.kt
@@ -14,7 +14,7 @@ public class IR(override val pointer: BytePointer) : Message(pointer) {
     /**
      * Writes this IR to a file at the given [path]
      */
-    public fun saveToFile(path: File) {
+    public fun writeToFile(path: File) {
         val content = toString()
 
         if (!path.exists()) {

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/IR.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/IR.kt
@@ -1,0 +1,39 @@
+package dev.supergrecko.vexe.llvm.ir
+
+import dev.supergrecko.vexe.llvm.support.Message
+import org.bytedeco.javacpp.BytePointer
+import java.io.File
+
+/**
+ * Specific wrapper representing a piece of LLVM IR
+ *
+ * This type is preferred over a [Message] for functions which specifically
+ * return a piece of IR because of its utility methods
+ */
+public class IR(override val pointer: BytePointer) : Message(pointer) {
+    /**
+     * Writes this IR to a file at the given [path]
+     */
+    public fun saveToFile(path: File) {
+        val content = toString()
+
+        if (!path.exists()) {
+            path.createNewFile()
+        }
+
+        path.writeText(content)
+    }
+
+    /**
+     * Compare this IR with another item
+     *
+     * IR Comparison is done by comparing the IR strings
+     */
+    public override fun equals(other: Any?): Boolean {
+        return toString() == other.toString()
+    }
+
+    public override fun hashCode(): Int = pointer.hashCode()
+
+    public override fun toString(): String = getString()
+}

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -191,21 +191,16 @@ public class Module internal constructor() : Disposable,
     /**
      * Print the module's IR to a file
      *
-     * This method returns a [Message] if there was an error while printing
-     * to file.
-     *
      * @see LLVM.LLVMPrintModuleToFile
      */
-    public fun toFile(path: File): Message? {
+    public fun saveIRToFile(path: File) {
         require(path.exists()) { "Cannot print to file which does not exist." }
 
         val message = BytePointer(0L)
         val result = LLVM.LLVMPrintModuleToFile(ref, path.absolutePath, message)
 
-        return if (result != 0) {
-            Message(message)
-        } else {
-            null
+        if (result != 0) {
+            throw RuntimeException(message.string)
         }
     }
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -196,10 +196,11 @@ public class Module internal constructor() : Disposable,
      *
      * @see LLVM.LLVMPrintModuleToFile
      */
-    public fun toFile(fileName: String): Message? {
-        val message = BytePointer()
+    public fun toFile(path: File): Message? {
+        require(path.exists()) { "Cannot print to file which does not exist." }
 
-        val result = LLVM.LLVMPrintModuleToFile(ref, fileName, message)
+        val message = BytePointer(0L)
+        val result = LLVM.LLVMPrintModuleToFile(ref, path.absolutePath, message)
 
         return if (result != 0) {
             Message(message)
@@ -209,14 +210,17 @@ public class Module internal constructor() : Disposable,
     }
 
     /**
-     * Get the IR as a string.
+     * Get the LLVM IR for this module
+     *
+     * This IR must be disposed via [IR.dispose] otherwise memory will
+     * be leaked.
      *
      * @see LLVM.LLVMPrintModuleToString
      */
-    public override fun toString(): String {
+    public fun getIR(): IR {
         val ir = LLVM.LLVMPrintModuleToString(ref)
 
-        return ir.string
+        return IR(ir)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Type.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Type.kt
@@ -53,17 +53,17 @@ public open class Type internal constructor() : ContainsReference<LLVMTypeRef> {
     }
 
     /**
-     * Moves the string representation into a Message
+     * Get the LLVM IR for this type
      *
-     * This message must be disposed via [Message.dispose] otherwise memory will
+     * This IR must be disposed via [IR.dispose] otherwise memory will
      * be leaked.
      *
      * @see LLVM.LLVMPrintTypeToString
      */
-    public fun getStringRepresentation(): Message {
+    public fun getIR(): IR {
         val ptr = LLVM.LLVMPrintTypeToString(ref)
 
-        return Message(ptr)
+        return IR(ptr)
     }
     //endregion Core::Types
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Value.kt
@@ -4,6 +4,7 @@ import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
 import dev.supergrecko.vexe.llvm.internal.contracts.Unreachable
 import dev.supergrecko.vexe.llvm.internal.util.fromLLVMBool
 import dev.supergrecko.vexe.llvm.internal.util.wrap
+import dev.supergrecko.vexe.llvm.support.Message
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
@@ -108,14 +109,17 @@ public open class Value internal constructor() :
     }
 
     /**
-     * Get the value in a string format
+     * Get the LLVM IR for this value
+     *
+     * This IR must be disposed via [IR.dispose] otherwise memory will
+     * be leaked.
      *
      * @see LLVM.LLVMPrintValueToString
      */
-    public fun dumpToString(): String {
+    public fun getIR(): IR {
         val ptr = LLVM.LLVMPrintValueToString(ref)
 
-        return ptr.string
+        return IR(ptr)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/support/Message.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/support/Message.kt
@@ -5,8 +5,14 @@ import org.bytedeco.javacpp.BytePointer
 import java.nio.ByteBuffer
 import org.bytedeco.llvm.global.LLVM
 
-public class Message(
-    private val pointer: BytePointer
+/**
+ * Class representing a byte pointer which must be de-allocated manually
+ *
+ * These byte pointers are retrieved via JNI. Failing to de-allocate them will
+ * leak memory.
+ */
+public open class Message(
+    protected open val pointer: BytePointer
 ) : Disposable {
     public override var valid: Boolean = true
 

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/IRTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/IRTest.kt
@@ -31,7 +31,7 @@ internal object IRTest : Spek({
         val file = utils.getTemporaryFile()
         val ir = IntType(128).getIR()
 
-        ir.saveToFile(file)
+        ir.writeToFile(file)
 
         val contents = file.readLines().joinToString("\n")
 

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/IRTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/IRTest.kt
@@ -1,0 +1,40 @@
+package dev.supergrecko.vexe.llvm.unit.ir
+
+import dev.supergrecko.vexe.llvm.TestUtils
+import dev.supergrecko.vexe.llvm.ir.Context
+import dev.supergrecko.vexe.llvm.ir.types.IntType
+import dev.supergrecko.vexe.llvm.setup
+import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
+
+internal object IRTest : Spek({
+    setup()
+
+    val utils: TestUtils by memoized()
+    val context: Context by memoized()
+
+    test("retrieving intermediate representation") {
+        val ty = IntType(32, context)
+        val ir = ty.getIR()
+
+        assertEquals("i32", ir.toString())
+    }
+
+    test("equality with other IR") {
+        val lhs = IntType(32).getIR()
+        val rhs = IntType(32).getIR()
+
+        assertEquals(lhs, rhs)
+    }
+
+    test("storing ir into file") {
+        val file = utils.getTemporaryFile()
+        val ir = IntType(128).getIR()
+
+        ir.saveToFile(file)
+
+        val contents = file.readLines().joinToString("\n")
+
+        assertEquals("i128", contents)
+    }
+})

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
@@ -129,7 +129,7 @@ internal object ModuleTest : Spek({
 
         test("printing to file") {
             val file = utils.getTemporaryFile()
-            val message = module.toFile(file.absolutePath)
+            val message = module.toFile(file)
             val content = Files.readAllLines(file.toPath())
                 .joinToString("")
 

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
@@ -122,14 +122,14 @@ internal object ModuleTest : Spek({
 
     group("dumping the ir representation of the module") {
         test("printing to string") {
-            val str = module.toString()
+            val str = module.getIR().toString()
 
             assertTrue { str.isNotEmpty() }
         }
 
         test("printing to file") {
             val file = utils.getTemporaryFile()
-            val message = module.toFile(file)
+            val message = module.saveIRToFile(file)
             val content = Files.readAllLines(file.toPath())
                 .joinToString("")
 

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
@@ -11,6 +11,7 @@ import dev.supergrecko.vexe.llvm.ir.types.VoidType
 import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
 import dev.supergrecko.vexe.llvm.setup
 import dev.supergrecko.vexe.llvm.support.VerifierFailureAction
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.spekframework.spek2.Spek
 import java.nio.file.Files
 import kotlin.test.assertEquals
@@ -129,11 +130,14 @@ internal object ModuleTest : Spek({
 
         test("printing to file") {
             val file = utils.getTemporaryFile()
-            val message = module.saveIRToFile(file)
+
+            assertDoesNotThrow {
+                module.saveIRToFile(file)
+            }
+
             val content = Files.readAllLines(file.toPath())
                 .joinToString("")
 
-            assertNull(message)
             assertTrue { content.isNotEmpty() }
         }
     }

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ModuleTest.kt
@@ -11,14 +11,12 @@ import dev.supergrecko.vexe.llvm.ir.types.VoidType
 import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
 import dev.supergrecko.vexe.llvm.setup
 import dev.supergrecko.vexe.llvm.support.VerifierFailureAction
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.spekframework.spek2.Spek
 import java.nio.file.Files
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal object ModuleTest : Spek({
@@ -131,9 +129,7 @@ internal object ModuleTest : Spek({
         test("printing to file") {
             val file = utils.getTemporaryFile()
 
-            assertDoesNotThrow {
-                module.saveIRToFile(file)
-            }
+            module.saveIRToFile(file)
 
             val content = Files.readAllLines(file.toPath())
                 .joinToString("")

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/TypeTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/TypeTest.kt
@@ -7,6 +7,7 @@ import dev.supergrecko.vexe.llvm.ir.types.StructType
 import dev.supergrecko.vexe.llvm.setup
 import org.spekframework.spek2.Spek
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal object TypeTest : Spek({
     setup()
@@ -46,9 +47,9 @@ internal object TypeTest : Spek({
     group("printing the string representation of a type") {
         test("integer types are prefixed with i") {
             val type = IntType(32)
-            val subject = type.getStringRepresentation().getString()
+            val ir = "i32"
 
-            assertEquals("i32", subject)
+            assertEquals(ir, type.getIR().toString())
         }
 
         test("structures print their body") {
@@ -57,9 +58,9 @@ internal object TypeTest : Spek({
                 true,
                 context
             )
-            val subject = struct.getStringRepresentation().getString()
+            val ir = "<{ i32 }>"
 
-            assertEquals("<{ i32 }>", subject)
+            assertEquals(ir, struct.getIR().toString())
         }
     }
 })

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ValueTest.kt
@@ -8,8 +8,6 @@ import dev.supergrecko.vexe.llvm.ir.types.IntType
 import dev.supergrecko.vexe.llvm.ir.types.VoidType
 import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
 import dev.supergrecko.vexe.llvm.setup
-import dev.supergrecko.vexe.test.TestSuite
-import org.bytedeco.llvm.global.LLVM
 import org.spekframework.spek2.Spek
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -93,7 +91,8 @@ internal object ValueTest : Spek({
 
     test("pulling a value in textual format") {
         val value = ConstantInt(IntType(32), 100)
+        val ir = "i32 100"
 
-        assertEquals("i32 100", value.dumpToString())
+        assertEquals(ir, value.getIR().toString())
     }
 })

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/RetInstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/RetInstructionTest.kt
@@ -58,7 +58,8 @@ internal class RetInstructionTest : TestSuite({
             .createAggregateRet(listOf(left, right))
 
         val ir = "  ret { i1, i1 } { i1 true, i1 false }"
-        assertEquals(ir, inst.dumpToString())
+
+        assertEquals(ir, inst.getIR().toString())
 
         cleanup(builder, module)
     }


### PR DESCRIPTION
There were inconsistencies in how different LLVM wrapping objects would print themselves as IR. Grouped everything under a single type, `IR`.

This type implements equals and IR based on the string representation of the IR. Tests included.