### PR TITLE
[tests] Create tests for Instructions API

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Builder.kt
@@ -151,11 +151,12 @@ public class Builder public constructor(
     /**
      * Insert an instruction into the current insertion point
      *
-     * If [name] is passed, [LLVM.LLVMInsertIntoBuilderWithName] is used.
+     * If [name] is passed, then the receiving [instruction] should not have
+     * a name.
      *
      * @see LLVM.LLVMInsertIntoBuilder
      */
-    public fun insert(instruction: Instruction, name: String?) {
+    public fun insert(instruction: Instruction, name: String? = null) {
         if (name != null) {
             LLVM.LLVMInsertIntoBuilderWithName(ref, instruction.ref, name)
         } else {

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Context.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Context.kt
@@ -93,6 +93,9 @@ public class Context public constructor(
     /**
      * Get the metadata kind id [name]
      *
+     * This is used for [Instruction.setMetadata] to convert string metadata
+     * keys to integer ones.
+     *
      * @see LLVM.LLVMGetMDKindID
      * @see LLVM.LLVMGetMDKindIDInContext
      */

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
@@ -209,6 +209,7 @@ public open class Instruction internal constructor() : Value(),
     //endregion Core::Instructions
 
     //region Core::Instructions::Terminators
+    // TODO: Move into Terminator interface
     /**
      * Get the number of successors that this terminator has
      *

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
@@ -34,31 +34,60 @@ public open class Instruction internal constructor() : Value(),
      *
      * @see LLVM.LLVMGetMetadata
      */
-    public fun getMetadata(kind: Int): Metadata {
-        require(hasMetadata()) {
-            "This instruction does not have any metadata attached"
-        }
-
+    public fun getMetadata(kind: Int): Value? {
         val value = LLVM.LLVMGetMetadata(ref, kind)
-        val md = LLVM.LLVMValueAsMetadata(value)
 
-        return Metadata(md)
+        return value?.let { Value(it) }
+    }
+
+    /**
+     * Get the metadata for this instruction
+     *
+     * This function converts the [kind] to the integer kind. This requires a
+     * context. You can pass a custom context via the [context] argument. By
+     * default, the context the instruction was created in will be used.
+     *
+     * @see LLVM.LLVMGetMetadata
+     */
+    public fun getMetadata(
+        kind: String,
+        context: Context = getContext()
+    ): Value? {
+        val kindId = context.getMetadataKindId(kind)
+
+        return getMetadata(kindId)
     }
 
     /**
      * Set the metadata for this instruction
      *
-     * TODO: Find replacement for the context used in MetadataAsValue
-     *
+     * This function uses numeric metadata ids. If you prefer to use string
+     * ids, use the overload for [String]
+     **
      * @see LLVM.LLVMSetMetadata
      */
-    public fun setMetadata(kind: Int, metadata: Metadata) {
-        val value = LLVM.LLVMMetadataAsValue(
-            getContext().ref,
-            metadata.ref
-        )
+    public fun setMetadata(kind: Int, metadata: Value) {
+        LLVM.LLVMSetMetadata(ref, kind, metadata.ref)
+    }
 
-        LLVM.LLVMSetMetadata(ref, kind, value)
+    /**
+     * Set the metadata for this instruction
+     *
+     * This function converts the [kind] to the integer kind. This requires a
+     * context. You can pass a custom context via the [context] argument. By
+     * default, the context the instruction was created in will be used.
+     *
+     * @see LLVM.LLVMGetMDKindIDInContext
+     * @see LLVM.LLVMSetMetadata
+     */
+    public fun setMetadata(
+        kind: String,
+        metadata: Value,
+        context: Context = getContext()
+    ) {
+        val kindId = context.getMetadataKindId(kind)
+
+        setMetadata(kindId, metadata)
     }
 
     /**
@@ -120,6 +149,8 @@ public open class Instruction internal constructor() : Value(),
      * @see LLVM.LLVMInstructionRemoveFromParent
      */
     public fun remove() {
+        require(getInstructionBlock() != null) { "This block has no parent" }
+
         LLVM.LLVMInstructionRemoveFromParent(ref)
     }
 
@@ -130,6 +161,9 @@ public open class Instruction internal constructor() : Value(),
      * @see LLVM.LLVMInstructionEraseFromParent
      */
     public fun delete() {
+        require(getInstructionBlock() != null) { "This block has no parent" }
+        require(valid) { "This instruction has already been deleted" }
+
         valid = false
 
         LLVM.LLVMInstructionEraseFromParent(ref)
@@ -193,7 +227,7 @@ public open class Instruction internal constructor() : Value(),
      *
      * @see LLVM.LLVMGetSuccessor
      */
-    public fun getSuccessor(index: Int): BasicBlock? {
+    public fun getSuccessor(index: Int): BasicBlock {
         require(isTerminator()) {
             "This instruction is not a terminator"
         }
@@ -203,7 +237,7 @@ public open class Instruction internal constructor() : Value(),
 
         val bb = LLVM.LLVMGetSuccessor(ref, index)
 
-        return wrap(bb) { BasicBlock(it) }
+        return BasicBlock(bb)
     }
 
     /**

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/Spek.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/Spek.kt
@@ -1,5 +1,9 @@
+// Eat all warnings about unused memoized variables
+@file:Suppress("UNUSED_VARIABLE")
+
 package dev.supergrecko.vexe.llvm
 
+import dev.supergrecko.vexe.llvm.ir.Builder
 import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Module
 import org.spekframework.spek2.dsl.Root
@@ -12,6 +16,11 @@ internal fun Root.setup() {
 
     val module by memoized(
         factory = { Module("test") },
+        destructor = { it.dispose() }
+    )
+
+    val builder by memoized(
+        factory = { Builder() },
         destructor = { it.dispose() }
     )
 

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ContextTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ContextTest.kt
@@ -7,7 +7,7 @@ import org.spekframework.spek2.Spek
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-internal class ContextTest : Spek({
+internal object ContextTest : Spek({
     setup()
 
     val context: Context by memoized()

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
@@ -5,9 +5,7 @@ import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Module
 import dev.supergrecko.vexe.llvm.ir.Metadata
 import dev.supergrecko.vexe.llvm.ir.types.FunctionType
-import dev.supergrecko.vexe.llvm.ir.types.IntType
 import dev.supergrecko.vexe.llvm.ir.types.VoidType
-import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
 import dev.supergrecko.vexe.llvm.setup
 import org.spekframework.spek2.Spek
 import kotlin.test.assertEquals
@@ -82,18 +80,13 @@ internal object InstructionTest : Spek({
         }
 
         test("iterating over instructions in a block") {
-            val function = module.addFunction("test", FunctionType(
+            val function = module.addFunction("testfn", FunctionType(
                 VoidType(), listOf(), false
             ))
             val block = function.createBlock("entry")
 
             builder.setPositionAtEnd(block)
-            val and = builder.build().createAnd(
-                ConstantInt(IntType(32), 1),
-                ConstantInt(IntType(32), 0),
-                "and"
-            )
-            builder.insert(and, "and")
+            builder.build().createBr(block)
             builder.build().createRetVoid()
 
             val first = block.getFirstInstruction()

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
@@ -3,8 +3,13 @@ package dev.supergrecko.vexe.llvm.unit.ir
 import dev.supergrecko.vexe.llvm.ir.Builder
 import dev.supergrecko.vexe.llvm.ir.Context
 import dev.supergrecko.vexe.llvm.ir.Module
+import dev.supergrecko.vexe.llvm.ir.Metadata
 import dev.supergrecko.vexe.llvm.setup
 import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 internal object InstructionTest : Spek({
     setup()
@@ -12,4 +17,40 @@ internal object InstructionTest : Spek({
     val builder: Builder by memoized()
     val context: Context by memoized()
     val module: Module by memoized()
+
+    group("instruction metadata") {
+        test("fresh instruction does not have metadata") {
+            val inst = builder.build().createRetVoid()
+
+            assertFalse { inst.hasMetadata() }
+        }
+
+        test("retrieving metadata from an instruction") {
+            val inst = builder.build().createRetVoid().apply {
+                setMetadata(
+                    "range",
+                    Metadata("yes").asValue(context)
+                )
+            }
+            val subject = inst.getMetadata("range")
+
+            assertTrue { inst.hasMetadata() }
+            assertNotNull(subject)
+        }
+
+        test("metadata bucket contains our metadata") {
+            val inst = builder.build().createRetVoid().apply {
+                setMetadata(
+                    "range",
+                    Metadata("yes").asValue(context)
+                )
+            }
+            val bucket = inst.getAllMetadataExceptDebugLocations()
+            val subject = bucket.getKind(0)
+            val id = context.getMetadataKindId("range")
+
+            assertEquals(1, bucket.size())
+            assertEquals(subject, id)
+        }
+    }
 })

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
@@ -1,6 +1,15 @@
 package dev.supergrecko.vexe.llvm.unit.ir
 
-import dev.supergrecko.vexe.test.TestSuite
+import dev.supergrecko.vexe.llvm.ir.Builder
+import dev.supergrecko.vexe.llvm.ir.Context
+import dev.supergrecko.vexe.llvm.ir.Module
+import dev.supergrecko.vexe.llvm.setup
+import org.spekframework.spek2.Spek
 
-internal class InstructionTest : TestSuite({
+internal object InstructionTest : Spek({
+    setup()
+
+    val builder: Builder by memoized()
+    val context: Context by memoized()
+    val module: Module by memoized()
 })


### PR DESCRIPTION
This re-adds the instructions tests as merged and reverted in #136 and #137 

**Description** (copied from #136)

This patch adds some basic tests for the Instructions base class.

Tests for Terminator instructions are not included as these will be added once terminators are moved.