### PR TITLE
[tests] Create factorial JIT integration test

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Builder.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Builder.kt
@@ -1663,9 +1663,8 @@ public class Builder public constructor(
             variable: String = ""
         ): CallInstruction {
             val args = PointerPointer(*arguments.map { it.ref }.toTypedArray())
-            val inst = LLVM.LLVMBuildCall2(
+            val inst = LLVM.LLVMBuildCall(
                 ref,
-                function.getType().ref,
                 function.ref,
                 args,
                 arguments.size,

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -577,11 +577,11 @@ public class Module internal constructor() : Disposable,
     public fun createExecutionEngine(): ExecutionEngine {
         val error = ByteArray(0)
         val ee = ExecutionEngine()
-        val success = LLVM.LLVMCreateExecutionEngineForModule(
+        val result = LLVM.LLVMCreateExecutionEngineForModule(
             ee.ref, ref, error
         )
 
-        return if (success.fromLLVMBool()) {
+        return if (result == 0) {
             ee
         } else {
             throw RuntimeException(error.contentToString())
@@ -596,11 +596,11 @@ public class Module internal constructor() : Disposable,
     public fun createInterpreter(): ExecutionEngine {
         val error = ByteArray(0)
         val ee = ExecutionEngine()
-        val success = LLVM.LLVMCreateInterpreterForModule(
+        val result = LLVM.LLVMCreateInterpreterForModule(
             ee.ref, ref, error
         )
 
-        return if (success.fromLLVMBool()) {
+        return if (result == 0) {
             ee
         } else {
             throw RuntimeException(error.contentToString())
@@ -616,11 +616,11 @@ public class Module internal constructor() : Disposable,
     public fun createJITCompiler(optimizationLevel: Int): ExecutionEngine {
         val error = ByteArray(0)
         val ee = ExecutionEngine()
-        val success = LLVM.LLVMCreateJITCompilerForModule(
+        val result = LLVM.LLVMCreateJITCompilerForModule(
             ee.ref, ref, optimizationLevel, error
         )
 
-        return if (success.fromLLVMBool()) {
+        return if (result == 0) {
             ee
         } else {
             throw RuntimeException(error.contentToString())
@@ -642,11 +642,11 @@ public class Module internal constructor() : Disposable,
     ): ExecutionEngine {
         val error = ByteArray(0)
         val ee = ExecutionEngine()
-        val success = LLVM.LLVMCreateMCJITCompilerForModule(
+        val result = LLVM.LLVMCreateMCJITCompilerForModule(
             ee.ref, ref, options.ref, options.ref.sizeof().toLong(), error
         )
 
-        return if (success.fromLLVMBool()) {
+        return if (result == 0) {
             ee
         } else {
             throw RuntimeException(error.contentToString())

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/integration/jni/Factorial.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/integration/jni/Factorial.kt
@@ -1,0 +1,120 @@
+package dev.supergrecko.vexe.llvm.integration.jni
+
+import dev.supergrecko.vexe.llvm.executionengine.GenericValue
+import dev.supergrecko.vexe.llvm.ir.Builder
+import dev.supergrecko.vexe.llvm.ir.CallConvention
+import dev.supergrecko.vexe.llvm.ir.IntPredicate
+import dev.supergrecko.vexe.llvm.ir.Module
+import dev.supergrecko.vexe.llvm.ir.PassManager
+import dev.supergrecko.vexe.llvm.ir.types.FunctionType
+import dev.supergrecko.vexe.llvm.ir.types.IntType
+import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
+import dev.supergrecko.vexe.llvm.support.VerifierFailureAction
+import org.bytedeco.llvm.global.LLVM
+import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
+
+internal object Factorial : Spek({
+    test("translated factorial example") {
+        // any call to LLVM.x is not implemented for llvm4kt yet
+        LLVM.LLVMLinkInMCJIT()
+        LLVM.LLVMInitializeNativeAsmPrinter()
+        LLVM.LLVMInitializeNativeAsmParser()
+        LLVM.LLVMInitializeNativeDisassembler()
+        LLVM.LLVMInitializeNativeTarget()
+
+        val module = Module("factorial")
+
+        val factorialType = FunctionType(
+            returns = IntType(32),
+            types = listOf(IntType(32)),
+            variadic = false
+        )
+        val factorial = module.addFunction("factorial", factorialType).apply {
+            setCallConvention(CallConvention.CCall)
+        }
+
+        val n = factorial.getParameter(0)
+        val entry = factorial.createBlock("entry")
+        val then = factorial.createBlock("then")
+        val otherwise = factorial.createBlock("otherwise")
+        val exit = factorial.createBlock("exit")
+
+        val builder = Builder().apply {
+            setPositionAtEnd(entry) // enter function
+
+            val condition = build().createICmp(
+                lhs = n,
+                predicate = IntPredicate.EQ,
+                rhs = ConstantInt(IntType(32), 0),
+                variable = "n == 0"
+            ) // compare param n with 0
+
+            val resultIfTrue = ConstantInt(IntType(32), 1)
+
+            // jump based on condition
+            build().createCondBr(condition, then, otherwise)
+            setPositionAtEnd(then) // enter then block
+            build().createBr(exit) // jump to exit
+            setPositionAtEnd(otherwise) // enter otherwise block
+
+            val nMinusOne = build().createSub(
+                lhs = n,
+                rhs = ConstantInt(IntType(32), 1),
+                variable = "n - 1"
+            ) // subtract 1 from n
+            val recursiveCall = build().createCall(
+                function = factorial,
+                arguments = listOf(nMinusOne),
+                variable = "factorial(n - 1)"
+            ) // call self recursively
+            val resultIfFalse = build().createMul(
+                lhs = n,
+                rhs = recursiveCall,
+                variable = "n * factorial(n - 1)"
+            )
+
+            build().createBr(exit) // jump to exit block
+            setPositionAtEnd(exit)
+
+            val result = build().createPhi(
+                incoming = IntType(32),
+                variable = "result"
+            ).apply {
+                addIncoming(
+                    values = listOf(resultIfTrue, resultIfFalse),
+                    blocks = listOf(then, otherwise)
+                )
+            }
+            build().createRet(result)
+        }
+
+        module.verify(VerifierFailureAction.PrintMessage)
+
+        val compiler = module.createJITCompiler(2)
+        val pass = PassManager(
+            LLVM.LLVMCreatePassManager()
+        )
+
+        LLVM.LLVMAddConstantPropagationPass(pass.ref)
+        LLVM.LLVMAddInstructionCombiningPass(pass.ref)
+        LLVM.LLVMAddPromoteMemoryToRegisterPass(pass.ref)
+        LLVM.LLVMAddGVNPass(pass.ref)
+        LLVM.LLVMAddCFGSimplificationPass(pass.ref)
+        LLVM.LLVMRunPassManager(pass.ref, module.ref)
+
+        val args = GenericValue(
+            type = IntType(32),
+            number = 10L, // factorial(10),
+            isSigned = false
+        )
+
+        val genericValueResult = compiler.runFunction(
+            function = factorial,
+            values = listOf(args)
+        )
+        val result = genericValueResult.toInt(true)
+
+        assertEquals(3628800, result)
+    }
+})


### PR DESCRIPTION
This test is a case to ensure a basic JIT example works via llvm4kt.

This PR also fixes two unexpected bugs.

- Use LLVMBuildCall over BuildCall2: Our way of inferring this type was clearly not valid. Uses LLVMBuildCall as a temporary fix
- Invert execution engine creation results: These would try to throw an error if it succeeded. Inverting the value of the results yields the expected value