### PR TITLE
[refactor] Rename Module.addFunction to Module.createFunction

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -14,7 +14,6 @@ import dev.supergrecko.vexe.llvm.ir.values.FunctionValue
 import dev.supergrecko.vexe.llvm.ir.values.GlobalAlias
 import dev.supergrecko.vexe.llvm.ir.values.GlobalVariable
 import dev.supergrecko.vexe.llvm.support.MemoryBuffer
-import dev.supergrecko.vexe.llvm.support.Message
 import dev.supergrecko.vexe.llvm.support.VerifierFailureAction
 import java.io.File
 import org.bytedeco.javacpp.BytePointer
@@ -375,7 +374,7 @@ public class Module internal constructor() : Disposable,
      *
      * @see LLVM.LLVMAddFunction
      */
-    public fun addFunction(name: String, type: FunctionType): FunctionValue {
+    public fun createFunction(name: String, type: FunctionType): FunctionValue {
         val value = LLVM.LLVMAddFunction(ref, name, type.ref)
 
         return FunctionValue(value)
@@ -474,7 +473,7 @@ public class Module internal constructor() : Disposable,
     /**
      * Add a global variable to this module
      *
-     * To add functions, use [addFunction]
+     * To add functions, use [createFunction]
      *
      * @see LLVM.LLVMAddGlobal
      */

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/integration/jni/Factorial.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/integration/jni/Factorial.kt
@@ -30,7 +30,7 @@ internal object Factorial : Spek({
             types = listOf(IntType(32)),
             variadic = false
         )
-        val factorial = module.addFunction("factorial", factorialType).apply {
+        val factorial = module.createFunction("factorial", factorialType).apply {
             setCallConvention(CallConvention.CCall)
         }
 

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/BuilderTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/BuilderTest.kt
@@ -17,7 +17,7 @@ internal class BuilderTest : TestSuite({
     describe("Should be able to position after basic block") {
         val builder = Builder()
         val module = Module("utils.ll")
-        val function = module.addFunction(
+        val function = module.createFunction(
             "utils",
             FunctionType(
                 VoidType(),
@@ -55,7 +55,7 @@ internal class BuilderTest : TestSuite({
     describe("Creation of call instruction") {
         val boolType = IntType(1)
         val module = Module("utils.ll").apply {
-            addFunction(
+            createFunction(
                 "utils",
                 FunctionType(
                     boolType,
@@ -68,7 +68,7 @@ internal class BuilderTest : TestSuite({
         val builder = Builder()
         val falseValue = ConstantInt(boolType, 0, false)
         val trueValue = ConstantInt(boolType, 1, false)
-        val caller = module.addFunction(
+        val caller = module.createFunction(
             "caller",
             FunctionType(
                 boolType,

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
@@ -10,7 +10,6 @@ import dev.supergrecko.vexe.llvm.ir.types.IntType
 import dev.supergrecko.vexe.llvm.ir.types.VoidType
 import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
 import dev.supergrecko.vexe.llvm.setup
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.assertThrows
 import org.spekframework.spek2.Spek
 import kotlin.test.assertEquals
@@ -71,7 +70,7 @@ internal object InstructionTest : Spek({
         }
 
         test("retrieving the residing block") {
-            val function = module.addFunction("test", FunctionType(
+            val function = module.createFunction("test", FunctionType(
                 VoidType(), listOf(), false
             )
             )
@@ -86,7 +85,7 @@ internal object InstructionTest : Spek({
         }
 
         test("iterating over instructions in a block") {
-            val function = module.addFunction("testfn", FunctionType(
+            val function = module.createFunction("testfn", FunctionType(
                 VoidType(), listOf(), false
             ))
             val block = function.createBlock("entry")
@@ -129,7 +128,7 @@ internal object InstructionTest : Spek({
         }
 
         test("non terminators may not have a successor assigned") {
-            val function = module.addFunction("test", FunctionType(
+            val function = module.createFunction("test", FunctionType(
                 VoidType(), listOf(), false
             ))
             val block = function.createBlock("entry")
@@ -172,7 +171,7 @@ internal object InstructionTest : Spek({
 
     group("cloning an instruction") {
         test("cloning creates an instruction without a parent") {
-            val function = module.addFunction("test", FunctionType(
+            val function = module.createFunction("test", FunctionType(
                 VoidType(), listOf(), false
             ))
             val block = function.createBlock("entry")

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/ValueTest.kt
@@ -23,7 +23,7 @@ internal object ValueTest : Spek({
         test("getting a manually set name") {
             assertFalse { context.isDiscardingValueNames() }
 
-            val value = module.addFunction("NotTrue", FunctionType(
+            val value = module.createFunction("NotTrue", FunctionType(
                 VoidType(),
                 listOf(),
                 variadic = false

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/BrInstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/BrInstructionTest.kt
@@ -16,7 +16,7 @@ internal class BrInstructionTest : TestSuite({
         val builder = Builder()
         val module = Module("test.ll")
 
-        val function = module.addFunction(
+        val function = module.createFunction(
             "test", FunctionType(
                 IntType(32), listOf(), false
             )

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/IndirectBrInstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/IndirectBrInstructionTest.kt
@@ -11,7 +11,7 @@ internal class IndirectBrInstructionTest : TestSuite({
     describe("Indirect Branching") {
         val builder = Builder()
         val module = Module("test.ll")
-        val function = module.addFunction(
+        val function = module.createFunction(
             "test", FunctionType(
                 IntType(32),
                 listOf(), false

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/RetInstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/RetInstructionTest.kt
@@ -41,7 +41,7 @@ internal class RetInstructionTest : TestSuite({
 
     describe("Creation of aggregate ret") {
         val module = Module("test.ll")
-        val function = module.addFunction("test", FunctionType(
+        val function = module.createFunction("test", FunctionType(
             StructType(listOf(IntType(1), IntType(1)), false),
             listOf(),
             false

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/SwitchInstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/SwitchInstructionTest.kt
@@ -12,7 +12,7 @@ import dev.supergrecko.vexe.test.TestSuite
 internal class SwitchInstructionTest : TestSuite({
     describe("Assigning same block to two conditions") {
         val module = Module("test.ll")
-        val function = module.addFunction("test", FunctionType(
+        val function = module.createFunction("test", FunctionType(
             StructType(listOf(IntType(1), IntType(1)), false),
             listOf(),
             false
@@ -32,7 +32,7 @@ internal class SwitchInstructionTest : TestSuite({
 
     describe("The expected cases can be passed") {
         val module = Module("test.ll")
-        val function = module.addFunction("test", FunctionType(
+        val function = module.createFunction("test", FunctionType(
             StructType(listOf(IntType(1), IntType(1)), false),
             listOf(),
             false


### PR DESCRIPTION
When we create something using LLVM, it should be named create. Adding is for attaching already-existing data.