### PR TITLE
[api] Create Iterator interface to iterate over LLVM iterators

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/ContainsReference.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/ContainsReference.kt
@@ -7,6 +7,11 @@ import org.bytedeco.javacpp.Pointer
  *
  * This enables code sharing using interfaces
  */
-public interface ContainsReference<T : Pointer> {
-    val ref: T
+public interface ContainsReference<P : Pointer> {
+    /**
+     * Get a raw pointer to an LLVM FFI Object
+     *
+     * @see Pointer
+     */
+    public val ref: P
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/Iterators.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/Iterators.kt
@@ -1,0 +1,63 @@
+package dev.supergrecko.vexe.llvm.internal.contracts
+
+import org.bytedeco.javacpp.Pointer
+
+/**
+ * Interface to wrap around LLVM iterators with Kotlin's built in iterators
+ *
+ * Store a reference to the FFI element [P] in [start] which will be used to
+ * determine if the iterator has a next item or not and to pull the next item
+ *
+ * @property start     The LLVM object reference to start iterating from
+ * @property yieldNext The effect to apply to get the next node
+ * @property apply     The effect to apply to create a new [T] from [P]
+ * @property head      The current pointer to work with
+ *
+ * TODO: Support backwards iteration
+ */
+public open class PointerIterator<T, P : Pointer>(
+    protected val start: P,
+    protected val yieldNext: (P) -> P?,
+    protected val apply: (P) -> T
+) : Iterator<T> {
+    protected var head: P? = null
+
+    /**
+     * Get the next item from the iterator
+     *
+     * This should only be called if the caller is certain the next item
+     * exists. Existence of the next item can be done with [hasNext]
+     */
+    public override fun next(): T {
+        // This iterator is yet to be used, return the starting node
+        val node = if (head == null) {
+            start
+        } else {
+            val node = yieldNext.invoke(start) ?: throw RuntimeException(
+                "Attempted to access non-existent next node of $start"
+            )
+
+            node
+        }
+
+        // Sets the head, guaranteeing that head == null will never yield
+        // true again for this iterator
+        head = node
+
+        return apply.invoke(node)
+    }
+
+    /**
+     * Checks if the iterator has another item ahead of it
+     *
+     * This should always be called before [next]
+     */
+    public override fun hasNext(): Boolean {
+        // A fresh iterator always has a next, the first item
+        return if (head == null) {
+            true
+        } else {
+            yieldNext.invoke(start) != null
+        }
+    }
+}

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/Iterators.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/internal/contracts/Iterators.kt
@@ -28,13 +28,14 @@ public open class PointerIterator<T, P : Pointer>(
      * This should only be called if the caller is certain the next item
      * exists. Existence of the next item can be done with [hasNext]
      */
-    public override fun next(): T {
+    public override operator fun next(): T {
         // This iterator is yet to be used, return the starting node
         val node = if (head == null) {
             start
         } else {
-            val node = yieldNext.invoke(start) ?: throw RuntimeException(
-                "Attempted to access non-existent next node of $start"
+            // Otherwise, grab the next node
+            val node = yieldNext.invoke(head!!) ?: throw RuntimeException(
+                "Attempted to access non-existent next node of $head"
             )
 
             node
@@ -52,12 +53,13 @@ public open class PointerIterator<T, P : Pointer>(
      *
      * This should always be called before [next]
      */
-    public override fun hasNext(): Boolean {
+    public override operator fun hasNext(): Boolean {
         // A fresh iterator always has a next, the first item
         return if (head == null) {
             true
         } else {
-            yieldNext.invoke(start) != null
+            // Otherwise, we check if the next element is null
+            yieldNext.invoke(head!!) != null
         }
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/BasicBlock.kt
@@ -145,25 +145,12 @@ public class BasicBlock internal constructor() : Validatable,
     /**
      * Get the start of the instruction iterator
      *
-     * @see LLVM.LLVMGetFirstInstruction
+     * @see PointerIterator
      */
-    public fun getFirstInstruction(): Instruction.Iterator? {
+    public fun getInstructionIterator(): Instruction.Iterator? {
         require(valid) { "Cannot use deleted block" }
 
         val instr = LLVM.LLVMGetFirstInstruction(ref)
-
-        return instr?.let { Instruction.Iterator(it) }
-    }
-
-    /**
-     * Get the end of the instruction iterator
-     *
-     * @see LLVM.LLVMGetLastInstruction
-     */
-    public fun getLastInstruction(): Instruction.Iterator? {
-        require(valid) { "Cannot use deleted block" }
-
-        val instr = LLVM.LLVMGetLastInstruction(ref)
 
         return instr?.let { Instruction.Iterator(it) }
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/BasicBlock.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.vexe.llvm.ir
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
+import dev.supergrecko.vexe.llvm.internal.contracts.PointerIterator
 import dev.supergrecko.vexe.llvm.internal.contracts.Validatable
 import dev.supergrecko.vexe.llvm.ir.values.FunctionValue
 import org.bytedeco.llvm.LLVM.LLVMBasicBlockRef
@@ -81,34 +82,6 @@ public class BasicBlock internal constructor() : Validatable,
     }
 
     /**
-     * Get the next block in the iterator
-     *
-     * Use with [BasicBlock.getNextBlock] and [BasicBlock.getPreviousBlock]
-     * to move the iterator
-     */
-    public fun getNextBlock(): BasicBlock? {
-        require(valid) { "Cannot use deleted block" }
-
-        val bb = LLVM.LLVMGetNextBasicBlock(ref)
-
-        return bb?.let { BasicBlock(it) }
-    }
-
-    /**
-     * Get the previous block in the iterator
-     *
-     * Use with [BasicBlock.getNextBlock] and [BasicBlock.getPreviousBlock]
-     * to move the iterator
-     */
-    public fun getPreviousBlock(): BasicBlock? {
-        require(valid) { "Cannot use deleted block" }
-
-        val bb = LLVM.LLVMGetPreviousBasicBlock(ref)
-
-        return bb?.let { BasicBlock(it) }
-    }
-
-    /**
      * Insert a basic block in front of this one in the function this block
      * resides in.
      *
@@ -170,35 +143,41 @@ public class BasicBlock internal constructor() : Validatable,
     }
 
     /**
-     * Get the first [Instruction] in the iterator
-     *
-     * Move the iterator with [Instruction.getNextInstruction] and
-     * [Instruction.getPreviousInstruction]
+     * Get the start of the instruction iterator
      *
      * @see LLVM.LLVMGetFirstInstruction
      */
-    public fun getFirstInstruction(): Instruction? {
+    public fun getFirstInstruction(): Instruction.Iterator? {
         require(valid) { "Cannot use deleted block" }
 
         val instr = LLVM.LLVMGetFirstInstruction(ref)
 
-        return instr?.let { Instruction(it) }
+        return instr?.let { Instruction.Iterator(it) }
     }
 
     /**
-     * Get the last [Instruction] in the iterator
-     *
-     * Move the iterator with [Instruction.getNextInstruction] and
-     * [Instruction.getPreviousInstruction]
+     * Get the end of the instruction iterator
      *
      * @see LLVM.LLVMGetLastInstruction
      */
-    public fun getLastInstruction(): Instruction? {
+    public fun getLastInstruction(): Instruction.Iterator? {
         require(valid) { "Cannot use deleted block" }
 
         val instr = LLVM.LLVMGetLastInstruction(ref)
 
-        return instr?.let { Instruction(it) }
+        return instr?.let { Instruction.Iterator(it) }
     }
     //endregion Core::BasicBlock
+
+    /**
+     * Class to perform iteration over basic blocks
+     *
+     * @see [PointerIterator]
+     */
+    public class Iterator(ref: LLVMBasicBlockRef) :
+        PointerIterator<BasicBlock, LLVMBasicBlockRef>(
+            start = ref,
+            yieldNext = { LLVM.LLVMGetNextBasicBlock(it) },
+            apply = { BasicBlock(it) }
+        )
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.vexe.llvm.ir
 
+import dev.supergrecko.vexe.llvm.internal.contracts.PointerIterator
 import dev.supergrecko.vexe.llvm.internal.contracts.Unreachable
 import dev.supergrecko.vexe.llvm.internal.contracts.Validatable
 import dev.supergrecko.vexe.llvm.internal.util.fromLLVMBool
@@ -117,32 +118,6 @@ public open class Instruction internal constructor() : Value(),
     }
 
     /**
-     * Get the next instruction inside of the basic block this resides in
-     *
-     * If this is the last instruction in the block, then null is returned
-     *
-     * @see LLVM.LLVMGetNextInstruction
-     */
-    public fun getNextInstruction(): Instruction? {
-        val inst = LLVM.LLVMGetNextInstruction(ref)
-
-        return inst?.let { Instruction(it) }
-    }
-
-    /**
-     * Get the first instruction inside of the basic block this resides in
-     *
-     * If this is the first instruction in the block, then null is returned
-     *
-     * @see LLVM.LLVMGetPreviousInstruction
-     */
-    public fun getPreviousInstruction(): Instruction? {
-        val inst = LLVM.LLVMGetPreviousInstruction(ref)
-
-        return inst?.let { Instruction(it) }
-    }
-
-    /**
      * Removes the instruction from the basic block it resides in
      *
      * @see LLVM.LLVMInstructionRemoveFromParent
@@ -253,4 +228,16 @@ public open class Instruction internal constructor() : Value(),
         LLVM.LLVMSetSuccessor(ref, index, block.ref)
     }
     //endregion Core::Instructions::Terminators
+
+    /**
+     * Class to perform iteration over instructions
+     *
+     * @see [PointerIterator]
+     */
+    public class Iterator(ref: LLVMValueRef) :
+        PointerIterator<Instruction, LLVMValueRef>(
+            start = ref,
+            yieldNext = { LLVM.LLVMGetNextInstruction(it) },
+            apply = { Instruction(it) }
+        )
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -280,31 +280,25 @@ public class Module internal constructor() : Disposable,
     }
 
     /**
-     * Get the first [NamedMetadataNode] in the iterator
-     *
-     * Move the iterator with [NamedMetadataNode.getNextNamedMetadata] and
-     * [NamedMetadataNode.getPreviousNamedMetadata]
+     * Get the start of the named metadata iterator
      *
      * @see LLVM.LLVMGetFirstNamedMetadata
      */
-    public fun getFirstNamedMetadata(): NamedMetadataNode? {
+    public fun getFirstNamedMetadata(): NamedMetadataNode.Iterator? {
         val md = LLVM.LLVMGetFirstNamedMetadata(ref)
 
-        return md?.let { NamedMetadataNode(it) }
+        return md?.let { NamedMetadataNode.Iterator(it) }
     }
 
     /**
-     * Get the last [NamedMetadataNode] in the iterator
-     *
-     * Move the iterator with [NamedMetadataNode.getNextNamedMetadata] and
-     * [NamedMetadataNode.getPreviousNamedMetadata]
+     * Get the end of the named metadata iterator
      *
      * @see LLVM.LLVMGetLastNamedMetadata
      */
-    public fun getLastNamedMetadata(): NamedMetadataNode? {
+    public fun getLastNamedMetadata(): NamedMetadataNode.Iterator? {
         val md = LLVM.LLVMGetLastNamedMetadata(ref)
 
-        return md?.let { NamedMetadataNode(it) }
+        return md?.let { NamedMetadataNode.Iterator(it) }
     }
 
     /**
@@ -391,31 +385,25 @@ public class Module internal constructor() : Disposable,
     }
 
     /**
-     * Get the first [FunctionValue] in the iterator
-     *
-     * Move the iterator with [FunctionValue.getNextFunction] and
-     * [FunctionValue.getPreviousFunction]
+     * Get the start of the function iterator
      *
      * @see LLVM.LLVMGetFirstFunction
      */
-    public fun getFirstFunction(): FunctionValue? {
+    public fun getFirstFunction(): FunctionValue.Iterator? {
         val fn = LLVM.LLVMGetFirstFunction(ref)
 
-        return fn?.let { FunctionValue(it) }
+        return fn?.let { FunctionValue.Iterator(it) }
     }
 
     /**
-     * Get the last [FunctionValue] in the iterator
-     *
-     * Move the iterator with [FunctionValue.getNextFunction] and
-     * [FunctionValue.getPreviousFunction]
+     * Get the end of the function iterator
      *
      * @see LLVM.LLVMGetLastFunction
      */
-    public fun getLastFunction(): FunctionValue? {
+    public fun getLastFunction(): FunctionValue.Iterator? {
         val fn = LLVM.LLVMGetLastFunction(ref)
 
-        return fn?.let { FunctionValue(it) }
+        return fn?.let { FunctionValue.Iterator(it) }
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -1,5 +1,6 @@
 package dev.supergrecko.vexe.llvm.ir
 
+import dev.supergrecko.vexe.llvm.internal.contracts.PointerIterator
 import dev.supergrecko.vexe.llvm.executionengine.ExecutionEngine
 import dev.supergrecko.vexe.llvm.executionengine.MCJITCompilerOptions
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
@@ -282,21 +283,10 @@ public class Module internal constructor() : Disposable,
     /**
      * Get the start of the named metadata iterator
      *
-     * @see LLVM.LLVMGetFirstNamedMetadata
+     * @see PointerIterator
      */
-    public fun getFirstNamedMetadata(): NamedMetadataNode.Iterator? {
+    public fun getNamedMetadataIterator(): NamedMetadataNode.Iterator? {
         val md = LLVM.LLVMGetFirstNamedMetadata(ref)
-
-        return md?.let { NamedMetadataNode.Iterator(it) }
-    }
-
-    /**
-     * Get the end of the named metadata iterator
-     *
-     * @see LLVM.LLVMGetLastNamedMetadata
-     */
-    public fun getLastNamedMetadata(): NamedMetadataNode.Iterator? {
-        val md = LLVM.LLVMGetLastNamedMetadata(ref)
 
         return md?.let { NamedMetadataNode.Iterator(it) }
     }
@@ -387,21 +377,10 @@ public class Module internal constructor() : Disposable,
     /**
      * Get the start of the function iterator
      *
-     * @see LLVM.LLVMGetFirstFunction
+     * @see PointerIterator
      */
-    public fun getFirstFunction(): FunctionValue.Iterator? {
+    public fun getFunctionIterator(): FunctionValue.Iterator? {
         val fn = LLVM.LLVMGetFirstFunction(ref)
-
-        return fn?.let { FunctionValue.Iterator(it) }
-    }
-
-    /**
-     * Get the end of the function iterator
-     *
-     * @see LLVM.LLVMGetLastFunction
-     */
-    public fun getLastFunction(): FunctionValue.Iterator? {
-        val fn = LLVM.LLVMGetLastFunction(ref)
 
         return fn?.let { FunctionValue.Iterator(it) }
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/NamedMetadataNode.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/NamedMetadataNode.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.vexe.llvm.ir
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
+import dev.supergrecko.vexe.llvm.internal.contracts.PointerIterator
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMNamedMDNodeRef
 import org.bytedeco.llvm.global.LLVM
@@ -16,28 +17,6 @@ public class NamedMetadataNode internal constructor() :
 
     //region Core::Modules
     /**
-     * Get the next [NamedMetadataNode] in the iterator
-     *
-     * @see LLVM.LLVMGetNextNamedMetadata
-     */
-    public fun getNextNamedMetadata(): NamedMetadataNode? {
-        val md = LLVM.LLVMGetNextNamedMetadata(ref)
-
-        return md?.let { NamedMetadataNode(it) }
-    }
-
-    /**
-     * Get the previous [NamedMetadataNode] in the iterator
-     *
-     * @see LLVM.LLVMGetPreviousNamedMetadata
-     */
-    public fun getPreviousNamedMetadata(): NamedMetadataNode? {
-        val md = LLVM.LLVMGetPreviousNamedMetadata(ref)
-
-        return md?.let { NamedMetadataNode(it) }
-    }
-
-    /**
      * Get the name of this metadata node
      *
      * @see LLVM.LLVMGetNamedMetadataName
@@ -48,4 +27,16 @@ public class NamedMetadataNode internal constructor() :
         return LLVM.LLVMGetNamedMetadataName(ref, length).string
     }
     //endregion Core::Modules
+
+    /**
+     * Class to perform iteration over named metadata nodes
+     *
+     * @see [PointerIterator]
+     */
+    public class Iterator(ref: LLVMNamedMDNodeRef) :
+        PointerIterator<NamedMetadataNode, LLVMNamedMDNodeRef>(
+            start = ref,
+            yieldNext = { LLVM.LLVMGetNextNamedMetadata(it) },
+            apply = { NamedMetadataNode(it) }
+        )
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Use.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Use.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.vexe.llvm.ir
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
+import dev.supergrecko.vexe.llvm.internal.contracts.PointerIterator
 import org.bytedeco.llvm.LLVM.LLVMUseRef
 import org.bytedeco.llvm.global.LLVM
 
@@ -53,4 +54,16 @@ public class Use internal constructor() : ContainsReference<LLVMUseRef> {
         return Value(value)
     }
     //endregion Core::Values::Usage
+
+    /**
+     * Class to perform iteration over targets
+     *
+     * @see [PointerIterator]
+     */
+    public class Iterator(ref: LLVMUseRef) :
+        PointerIterator<Use, LLVMUseRef>(
+            start = ref,
+            yieldNext = { LLVM.LLVMGetNextUse(it) },
+            apply = { Use(it) }
+        )
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Value.kt
@@ -153,16 +153,14 @@ public open class Value internal constructor() :
 
     //region Core::Values::Usage
     /**
-     * Get the first [Use] for this value
-     *
-     * Move the iterator with [Use.getNextUse]
+     * Get the start of the use iterator
      *
      * @see LLVM.LLVMGetFirstUse
      */
-    public fun getFirstUse(): Use? {
+    public fun getFirstUse(): Use.Iterator? {
         val use = LLVM.LLVMGetFirstUse(ref)
 
-        return use?.let { Use(it) }
+        return use?.let { Use.Iterator(it) }
     }
     //endregion Core::Values::Usage
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/FunctionValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/FunctionValue.kt
@@ -74,21 +74,10 @@ public open class FunctionValue internal constructor() : Value(),
     /**
      * Get the start of the basic block iterator
      *
-     * @see LLVM.LLVMGetFirstBasicBlock
+     * @see PointerIterator
      */
-    public fun getFirstBlock(): BasicBlock.Iterator? {
+    public fun getBlockIterator(): BasicBlock.Iterator? {
         val bb = LLVM.LLVMGetFirstBasicBlock(ref)
-
-        return bb?.let { BasicBlock.Iterator(it) }
-    }
-
-    /**
-     * Get the end of the basic block iterator
-     *
-     * @see LLVM.LLVMGetLastBasicBlock
-     */
-    public fun getLastBlock(): BasicBlock.Iterator? {
-        val bb = LLVM.LLVMGetLastBasicBlock(ref)
 
         return bb?.let { BasicBlock.Iterator(it) }
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/target/Target.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/target/Target.kt
@@ -1,6 +1,7 @@
 package dev.supergrecko.vexe.llvm.target
 
 import dev.supergrecko.vexe.llvm.internal.contracts.ContainsReference
+import dev.supergrecko.vexe.llvm.internal.contracts.PointerIterator
 import dev.supergrecko.vexe.llvm.internal.util.fromLLVMBool
 import org.bytedeco.javacpp.BytePointer
 import org.bytedeco.llvm.LLVM.LLVMTargetRef
@@ -118,4 +119,16 @@ public class Target internal constructor() :
         }
     }
     //endregion Target
+
+    /**
+     * Class to perform iteration over targets
+     *
+     * @see [PointerIterator]
+     */
+    public class Iterator(ref: LLVMTargetRef) :
+        PointerIterator<Target, LLVMTargetRef>(
+            start = ref,
+            yieldNext = { LLVM.LLVMGetNextTarget(it) },
+            apply = { Target(it) }
+        )
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/target/TargetMachine.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/target/TargetMachine.kt
@@ -48,16 +48,14 @@ public class TargetMachine internal constructor() :
     }
 
     /**
-     * Get the first [Target] in the iterator
-     *
-     * Move the iterator with [Target.getNextTarget]
+     * Get the start of the target iterator
      *
      * @see LLVM.LLVMGetNextTarget
      */
-    public fun getFirstTarget(): Target? {
+    public fun getFirstTarget(): Target.Iterator? {
         val target = LLVM.LLVMGetFirstTarget()
 
-        return target?.let { Target(it) }
+        return target?.let { Target.Iterator(it) }
     }
 
     /**

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/CallbackTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/CallbackTest.kt
@@ -6,7 +6,7 @@ import org.bytedeco.llvm.global.LLVM
 import org.spekframework.spek2.Spek
 import kotlin.test.assertNotNull
 
-internal class CallbackTest : Spek({
+internal object CallbackTest : Spek({
     setup()
 
     val context: Context by memoized()

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/ConversionsTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/ConversionsTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-internal class ConversionsTest : Spek({
+internal object ConversionsTest : Spek({
     group("int to boolean conversion") {
         test("0 and 1 match false and true") {
             assertTrue { 1.fromLLVMBool() }

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/IteratorTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/internal/IteratorTest.kt
@@ -1,0 +1,60 @@
+package dev.supergrecko.vexe.llvm.unit.internal
+
+import dev.supergrecko.vexe.llvm.ir.Module
+import dev.supergrecko.vexe.llvm.ir.types.FunctionType
+import dev.supergrecko.vexe.llvm.ir.types.IntType
+import dev.supergrecko.vexe.llvm.setup
+import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal object IteratorTest : Spek({
+    setup()
+
+    val module: Module by memoized()
+
+    test("iterators are null if no elements are found") {
+        val iter = module.getFunctionIterator()
+
+        assertNull(iter)
+    }
+
+    test("non null iterators will always yield an item") {
+        val fnTy = FunctionType(IntType(32), listOf(), false)
+        val fn = module.createFunction("Test", fnTy)
+        val iter = module.getFunctionIterator()
+
+        assertNotNull(iter)
+        assertTrue { iter.hasNext() }
+
+        val subject = iter.next()
+
+        assertEquals(fn.ref, subject.ref)
+        assertFalse { iter.hasNext() }
+    }
+
+    test("you may iterate over elements in a for loop") {
+        val fnTy = FunctionType(IntType(32), listOf(), false)
+
+        module.apply {
+            createFunction("A", fnTy)
+            createFunction("B", fnTy)
+            createFunction("C", fnTy)
+        }
+
+        val iter = module.getFunctionIterator()
+        var count = 0
+
+        assertNotNull(iter)
+
+        for (i in iter) {
+            assertNotNull(i)
+            count++
+        }
+
+        assertEquals(3, count)
+    }
+})

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/InstructionTest.kt
@@ -83,26 +83,6 @@ internal object InstructionTest : Spek({
             assertNotNull(subject)
             assertEquals(block.ref, subject.ref)
         }
-
-        test("iterating over instructions in a block") {
-            val function = module.createFunction("testfn", FunctionType(
-                VoidType(), listOf(), false
-            ))
-            val block = function.createBlock("entry")
-
-            builder.setPositionAtEnd(block)
-            builder.build().createBr(block)
-            builder.build().createRetVoid()
-
-            val first = block.getFirstInstruction()
-            val second = first?.getNextInstruction()
-            val subject = second?.getPreviousInstruction()
-
-            assertNotNull(first)
-            assertNotNull(second)
-            assertNotNull(subject)
-            assertEquals(first.ref, subject.ref)
-        }
     }
 
     group("successors of terminating basic blocks") {

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/NamedMetadataTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/NamedMetadataTest.kt
@@ -7,6 +7,7 @@ import dev.supergrecko.vexe.llvm.ir.values.constants.ConstantInt
 import dev.supergrecko.vexe.llvm.setup
 import org.spekframework.spek2.Spek
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -18,27 +19,25 @@ internal object NamedMetadataTest : Spek({
 
     group("getting metadata from a module") {
         test("a module without metadata does not have a first or last") {
-            val first = module.getFirstNamedMetadata()
-            val last = module.getLastNamedMetadata()
+            val iter = module.getNamedMetadataIterator()
 
-            assertNull(first)
-            assertNull(last)
+            assertNull(iter)
         }
 
         test("a module with metadata can use the iterator") {
             module.getOrCreateNamedMetadata("one")
             module.getOrCreateNamedMetadata("two")
 
-            val iterator = module.getFirstNamedMetadata()
+            val iter = module.getNamedMetadataIterator()
 
-            assertNotNull(iterator)
-            assertTrue { iterator.hasNext() }
+            assertNotNull(iter)
+            assertTrue { iter.hasNext() }
 
-            val first = iterator.next()
+            val first = iter.next()
 
-            assertTrue { iterator.hasNext() }
+            assertTrue { iter.hasNext() }
 
-            val second = iterator.next()
+            val second = iter.next()
 
             assertEquals("one", first.getName())
             assertEquals("two", second.getName())

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/NamedMetadataTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/NamedMetadataTest.kt
@@ -9,6 +9,7 @@ import org.spekframework.spek2.Spek
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal object NamedMetadataTest : Spek({
     setup()
@@ -28,11 +29,19 @@ internal object NamedMetadataTest : Spek({
             module.getOrCreateNamedMetadata("one")
             module.getOrCreateNamedMetadata("two")
 
-            val first = module.getFirstNamedMetadata()
-            val second = first?.getNextNamedMetadata()
+            val iterator = module.getFirstNamedMetadata()
 
-            assertEquals("one", first?.getName())
-            assertEquals("two", second?.getName())
+            assertNotNull(iterator)
+            assertTrue { iterator.hasNext() }
+
+            val first = iterator.next()
+
+            assertTrue { iterator.hasNext() }
+
+            val second = iterator.next()
+
+            assertEquals("one", first.getName())
+            assertEquals("two", second.getName())
         }
 
         test("finding a metadata node by name") {


### PR DESCRIPTION
LLVM Provides a set of GetNextT and GetPreviousT functions which are wrappers around LLVM's C++ iterators.

The problem with these, like many other things from FFI is that they should only be called on specific things, in this case T's which came from a GetFirstT or GetLastT function. Calling it on anything else gives the user an access violation, LLVM segfaults and the JVM crashes. This is not wanted behavior.

This patch introduces the PointerIterator which is an iterator specialized to iterate over foreign objects from LLVM. The user does not have to care about how this iterator is implemented, as it follows the standard guidelines as Kotlin's own Iterator<T> type.

**Known Issues**:
There is no simple way to do backwards iteration with this because of how the initial state of these iterators is the first item in the C++ iterator, not a default none state. This causes issues with state and invalid backwards or forwards iteration under certain circumstances. A TODO item is left for this.