### PR TITLE
[cleanup] Deallocate unused SizeT/IntPointers

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Attribute.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Attribute.kt
@@ -72,9 +72,12 @@ public class Attribute internal constructor() :
     public fun getStringKind(): String {
         require(isStringAttribute()) { "This is not a string attribute" }
 
-        val ptr = IntPointer(0)
+        val len = IntPointer(0)
+        val ptr = LLVM.LLVMGetStringAttributeKind(ref, len)
 
-        return LLVM.LLVMGetStringAttributeKind(ref, ptr).string
+        len.deallocate()
+
+        return ptr.string
     }
 
     /**
@@ -85,9 +88,12 @@ public class Attribute internal constructor() :
     public fun getStringValue(): String {
         require(isStringAttribute()) { "This is not a string attribute" }
 
-        val ptr = IntPointer(0)
+        val len = IntPointer(0)
+        val ptr = LLVM.LLVMGetStringAttributeValue(ref, len)
 
-        return LLVM.LLVMGetStringAttributeValue(ref, ptr).string
+        len.deallocate()
+
+        return ptr.string
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
@@ -10,7 +10,7 @@ import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public open class Instruction internal constructor() : Value(),
-    DebugLocationValue, Validatable {
+    DebugLocationValue, Validatable, Cloneable {
     public override var valid = true
 
     public constructor(llvmRef: LLVMValueRef) : this() {
@@ -164,7 +164,7 @@ public open class Instruction internal constructor() : Value(),
      *
      * @see LLVM.LLVMInstructionClone
      */
-    public fun clone(): Instruction {
+    public override fun clone(): Instruction {
         val clone = LLVM.LLVMInstructionClone(ref)
 
         return Instruction(clone)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Metadata.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Metadata.kt
@@ -82,8 +82,11 @@ public class Metadata internal constructor() :
         context: Context = Context.getGlobalContext()
     ): String {
         val len = IntPointer(0)
+        val ptr = LLVM.LLVMGetMDString(asValue(context).ref, len)
 
-        return LLVM.LLVMGetMDString(asValue(context).ref, len).string
+        len.deallocate()
+
+        return ptr.string
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -20,12 +20,11 @@ import org.bytedeco.javacpp.BytePointer
 import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.javacpp.SizeTPointer
 import org.bytedeco.llvm.LLVM.LLVMModuleRef
-import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
 public class Module internal constructor() : Disposable,
-    ContainsReference<LLVMModuleRef> {
+    ContainsReference<LLVMModuleRef>, Cloneable {
     public override lateinit var ref: LLVMModuleRef
         internal set
     public override var valid: Boolean = true
@@ -59,7 +58,10 @@ public class Module internal constructor() : Disposable,
      * @see LLVM.LLVMGetModuleIdentifier
      */
     public fun getModuleIdentifier(): String {
-        val ptr = LLVM.LLVMGetModuleIdentifier(ref, SizeTPointer(0))
+        val len = SizeTPointer(0)
+        val ptr = LLVM.LLVMGetModuleIdentifier(ref, len)
+
+        len.deallocate()
 
         return ptr.string
     }
@@ -82,7 +84,10 @@ public class Module internal constructor() : Disposable,
      * @see LLVM.LLVMGetSourceFileName
      */
     public fun getSourceFileName(): String {
-        val ptr = LLVM.LLVMGetSourceFileName(ref, SizeTPointer(0))
+        val len = SizeTPointer(0)
+        val ptr = LLVM.LLVMGetSourceFileName(ref, len)
+
+        len.deallocate()
 
         return ptr.string
     }
@@ -225,8 +230,10 @@ public class Module internal constructor() : Disposable,
      * @see LLVM.LLVMGetModuleInlineAsm
      */
     public fun getInlineAssembly(): String {
-        val length = SizeTPointer(0)
-        val asm = LLVM.LLVMGetModuleInlineAsm(ref, length)
+        val len = SizeTPointer(0)
+        val asm = LLVM.LLVMGetModuleInlineAsm(ref, len)
+
+        len.deallocate()
 
         return asm.string
     }
@@ -390,7 +397,7 @@ public class Module internal constructor() : Disposable,
      *
      * @see LLVM.LLVMCloneModule
      */
-    public fun clone(): Module {
+    public override fun clone(): Module {
         val mod = LLVM.LLVMCloneModule(ref)
 
         return Module(mod)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
@@ -63,9 +63,12 @@ public class ModuleFlagEntries internal constructor() :
             )
         }
 
-        val length = SizeTPointer(0)
+        val len = SizeTPointer(0)
+        val ptr = LLVM.LLVMModuleFlagEntriesGetKey(ref, index, len)
 
-        return LLVM.LLVMModuleFlagEntriesGetKey(ref, index, length).string
+        len.deallocate()
+
+        return ptr.string
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/NamedMetadataNode.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/NamedMetadataNode.kt
@@ -22,9 +22,12 @@ public class NamedMetadataNode internal constructor() :
      * @see LLVM.LLVMGetNamedMetadataName
      */
     public fun getName(): String {
-        val length = SizeTPointer(0)
+        val len = SizeTPointer(0)
+        val ptr = LLVM.LLVMGetNamedMetadataName(ref, len)
 
-        return LLVM.LLVMGetNamedMetadataName(ref, length).string
+        len.deallocate()
+
+        return ptr.string
     }
     //endregion Core::Modules
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Value.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Value.kt
@@ -30,6 +30,8 @@ public open class Value internal constructor() :
         val len = SizeTPointer(0)
         val ptr = LLVM.LLVMGetValueName2(ref, len)
 
+        len.deallocate()
+
         return ptr.string
     }
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/FunctionType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/FunctionType.kt
@@ -27,12 +27,12 @@ public class FunctionType internal constructor() : Type() {
         types: List<Type>,
         variadic: Boolean
     ) : this() {
-        val arr = ArrayList(types.map { it.ref }).toTypedArray()
+        val ptr = PointerPointer(*types.map { it.ref }.toTypedArray())
 
         ref = LLVM.LLVMFunctionType(
             returns.ref,
-            PointerPointer(*arr),
-            arr.size,
+            ptr,
+            types.size,
             variadic.toLLVMBool()
         )
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/StructType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/StructType.kt
@@ -33,10 +33,14 @@ public class StructType internal constructor() : Type(),
         packed: Boolean,
         ctx: Context = Context.getGlobalContext()
     ) : this() {
-        val arr = ArrayList(types.map { it.ref }).toTypedArray()
+        val ptr = PointerPointer(*types.map { it.ref }.toTypedArray())
 
-        ref =
-            LLVM.LLVMStructTypeInContext(ctx.ref, PointerPointer(*arr), arr.size, packed.toLLVMBool())
+        ref = LLVM.LLVMStructTypeInContext(
+            ctx.ref,
+            ptr,
+            types.size,
+            packed.toLLVMBool()
+        )
     }
 
     /**
@@ -86,14 +90,12 @@ public class StructType internal constructor() : Type(),
      *
      * @see LLVM.LLVMStructSetBody
      */
-    public fun setBody(elementTypes: List<Type>, packed: Boolean) {
+    public fun setBody(types: List<Type>, packed: Boolean) {
         require(isOpaque()) { "Cannot set body of non-opaque struct" }
 
-        val types = elementTypes.map { it.ref }
-        val array = ArrayList(types).toTypedArray()
-        val ptr = PointerPointer(*array)
+        val ptr = PointerPointer(*types.map { it.ref }.toTypedArray())
 
-        LLVM.LLVMStructSetBody(ref, ptr, array.size, packed.toLLVMBool())
+        LLVM.LLVMStructSetBody(ref, ptr, types.size, packed.toLLVMBool())
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/IntrinsicFunction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/IntrinsicFunction.kt
@@ -60,15 +60,14 @@ public class IntrinsicFunction internal constructor() {
     public fun getOverloadedName(parameters: List<Type>): String {
         require(isOverloaded()) { "This intrinsic is not overloaded." }
 
-        val ptr = SizeTPointer(0)
-        val arr = ArrayList(parameters.map { it.ref })
-            .toTypedArray()
+        val len = SizeTPointer(0)
+        val ptr = PointerPointer(*parameters.map { it.ref }.toTypedArray())
 
         return LLVM.LLVMIntrinsicCopyOverloadedName(
             id,
-            PointerPointer(*arr),
+            ptr,
             parameters.size.toLong(),
-            ptr
+            len
         )
     }
 
@@ -78,9 +77,12 @@ public class IntrinsicFunction internal constructor() {
      * @see LLVM.LLVMIntrinsicGetName
      */
     public fun getName(): String {
-        val ptr = SizeTPointer(0)
+        val len = SizeTPointer(0)
+        val ptr = LLVM.LLVMIntrinsicGetName(id, len)
 
-        return LLVM.LLVMIntrinsicGetName(id, ptr).string
+        len.deallocate()
+
+        return ptr.string
     }
 
     /**
@@ -92,13 +94,11 @@ public class IntrinsicFunction internal constructor() {
         module: Module,
         parameters: List<Type>
     ): FunctionValue {
-        val arr = ArrayList(parameters.map { it.ref })
-            .toTypedArray()
-
+        val ptr = PointerPointer(*parameters.map { it.ref }.toTypedArray())
         val decl = LLVM.LLVMGetIntrinsicDeclaration(
             module.ref,
             id,
-            PointerPointer(*arr),
+            ptr,
             parameters.size.toLong()
         )
 
@@ -111,13 +111,11 @@ public class IntrinsicFunction internal constructor() {
      * @see LLVM.LLVMIntrinsicGetType
      */
     public fun getType(context: Context, parameters: List<Type>): FunctionType {
-        val arr = ArrayList(parameters.map { it.ref })
-            .toTypedArray()
-
+        val ptr = PointerPointer(*parameters.map { it.ref }.toTypedArray())
         val type = LLVM.LLVMIntrinsicGetType(
             context.ref,
             id,
-            PointerPointer(*arr),
+            ptr,
             parameters.size.toLong()
         )
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantArray.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantArray.kt
@@ -28,9 +28,9 @@ public class ConstantArray internal constructor() : Value(),
      * @see LLVM.LLVMConstArray
      */
     public constructor(type: Type, values: List<Value>) : this() {
-        val ptr = values.map { it.ref }.toTypedArray()
+        val ptr = PointerPointer(*values.map { it.ref }.toTypedArray())
 
-        ref = LLVM.LLVMConstArray(type.ref, PointerPointer(*ptr), ptr.size)
+        ref = LLVM.LLVMConstArray(type.ref, ptr, values.size)
     }
 
     /**
@@ -69,7 +69,10 @@ public class ConstantArray internal constructor() : Value(),
     public fun getAsString(): String {
         require(isConstantString())
 
-        val ptr = LLVM.LLVMGetAsString(ref, SizeTPointer(0))
+        val len = SizeTPointer(0)
+        val ptr = LLVM.LLVMGetAsString(ref, len)
+
+        len.deallocate()
 
         return ptr.string
     }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantStruct.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantStruct.kt
@@ -27,12 +27,12 @@ public class ConstantStruct internal constructor() : Value(),
         packed: Boolean,
         context: Context = Context.getGlobalContext()
     ) : this() {
-        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
+        val ptr = PointerPointer(*values.map { it.ref }.toTypedArray())
 
         ref = LLVM.LLVMConstStructInContext(
             context.ref,
-            PointerPointer(*ptr),
-            ptr.size,
+            ptr,
+            values.size,
             packed.toLLVMBool()
         )
     }
@@ -43,12 +43,8 @@ public class ConstantStruct internal constructor() : Value(),
      * @see LLVM.LLVMConstNamedStruct
      */
     public constructor(type: StructType, values: List<Value>) : this() {
-        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
+        val ptr = PointerPointer(*values.map { it.ref }.toTypedArray())
 
-        ref = LLVM.LLVMConstNamedStruct(
-            type.ref,
-            PointerPointer(*ptr),
-            ptr.size
-        )
+        ref = LLVM.LLVMConstNamedStruct(type.ref, ptr, values.size)
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantVector.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantVector.kt
@@ -25,9 +25,9 @@ public class ConstantVector internal constructor() : Value(),
      * @see LLVM.LLVMConstVector
      */
     public constructor(values: List<Value>) : this() {
-        val ptr = ArrayList(values.map { it.ref }).toTypedArray()
+        val ptr = PointerPointer(*values.map { it.ref }.toTypedArray())
 
-        ref = LLVM.LLVMConstVector(PointerPointer(*ptr), ptr.size)
+        ref = LLVM.LLVMConstVector(ptr, values.size)
     }
 
     /**

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/AggregateValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/AggregateValue.kt
@@ -19,12 +19,11 @@ public interface AggregateValue : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMConstInBoundsGEP
      */
     public fun getGEP(inbounds: Boolean, indices: List<ConstantInt>): Value {
-        val ptr = indices.map { it.ref }.toTypedArray()
-
+        val ptr = PointerPointer(*indices.map { it.ref }.toTypedArray())
         val ref = if (inbounds) {
-            LLVM.LLVMConstInBoundsGEP(ref, PointerPointer(*ptr), indices.size)
+            LLVM.LLVMConstInBoundsGEP(ref, ptr, indices.size)
         } else {
-            LLVM.LLVMConstGEP(ref, PointerPointer(*ptr), indices.size)
+            LLVM.LLVMConstGEP(ref, ptr, indices.size)
         }
 
         return Value(ref)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/DebugLocationValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/traits/DebugLocationValue.kt
@@ -17,9 +17,12 @@ public interface DebugLocationValue : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMGetDebugLocDirectory
      */
     public fun getDebugLocationDirectory(): String? {
-        val length = IntPointer(0)
+        val len = IntPointer(0)
+        val ptr = LLVM.LLVMGetDebugLocDirectory(ref, len)
 
-        return LLVM.LLVMGetDebugLocDirectory(ref, length)?.string
+        len.deallocate()
+
+        return ptr?.string
     }
 
     /**
@@ -28,9 +31,12 @@ public interface DebugLocationValue : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMGetDebugLocFilename
      */
     public fun getDebugLocationFilename(): String? {
-        val length = IntPointer(0)
+        val len = IntPointer(0)
+        val ptr = LLVM.LLVMGetDebugLocFilename(ref, len)
 
-        return LLVM.LLVMGetDebugLocFilename(ref, length)?.string
+        len.deallocate()
+
+        return ptr?.string
     }
 
     /**


### PR DESCRIPTION
A lot of allocated pointers were left unused until the JVM would decide to delete them, these are now manually deallocated after use.