### PR TITLE
[api] Create String overload for Message

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/IR.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/IR.kt
@@ -33,7 +33,7 @@ public class IR(pointer: BytePointer) : Message(pointer) {
         return toString() == other.toString()
     }
 
-    public override fun hashCode(): Int = pointer.hashCode()
+    public override fun hashCode(): Int = ref.hashCode()
 
     public override fun toString(): String = getString()
 }


### PR DESCRIPTION
The LLVM-C API documents a LLVMCreateMessage function which should be used to construct user defined "Messages".

The Message class now has a constructor overload for a String.