### PR TITLE
[api] Differentiate between GlobalValue types and make GlobalVariable extend GlobalValue

### DIFF
--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalValue.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalValue.kt
@@ -22,6 +22,8 @@ public open class GlobalValue internal constructor() : ConstantValue() {
     /**
      * Get the linkage type
      *
+     * TODO: Research invalid matches
+     *
      * @see LLVM.LLVMGetLinkage
      */
     public fun getLinkage(): Linkage {
@@ -44,8 +46,10 @@ public open class GlobalValue internal constructor() : ConstantValue() {
      *
      * @see LLVM.LLVMGetSection
      */
-    public fun getSection(): String {
-        return LLVM.LLVMGetSection(ref).string
+    public fun getSection(): String? {
+        val ptr = LLVM.LLVMGetSection(ref)
+
+        return ptr?.string
     }
 
     /**
@@ -139,11 +143,14 @@ public open class GlobalValue internal constructor() : ConstantValue() {
     }
 
     /**
-     * Get the type of this value
+     * Returns the "value type"
+     *
+     * This differs from the formal type of a global value which is always a
+     * pointer type.
      *
      * @see LLVM.LLVMGlobalGetValueType
      */
-    public override fun getType(): Type {
+    public fun getValueType(): Type {
         val ty = LLVM.LLVMGlobalGetValueType(ref)
 
         return Type(ty)

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalVariable.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/GlobalVariable.kt
@@ -9,7 +9,7 @@ import dev.supergrecko.vexe.llvm.ir.values.traits.DebugLocationValue
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class GlobalVariable internal constructor() : Value(),
+public class GlobalVariable internal constructor() : GlobalValue(),
     DebugLocationValue {
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/values/GlobalValueTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/values/GlobalValueTest.kt
@@ -1,16 +1,93 @@
 package dev.supergrecko.vexe.llvm.unit.ir.values
 
+import dev.supergrecko.vexe.llvm.ir.DLLStorageClass
 import dev.supergrecko.vexe.llvm.ir.Module
+import dev.supergrecko.vexe.llvm.ir.TypeKind
+import dev.supergrecko.vexe.llvm.ir.UnnamedAddress
+import dev.supergrecko.vexe.llvm.ir.Visibility
 import dev.supergrecko.vexe.llvm.ir.types.IntType
 import dev.supergrecko.vexe.llvm.ir.values.GlobalValue
 import dev.supergrecko.vexe.llvm.setup
 import kotlin.test.assertEquals
 import org.spekframework.spek2.Spek
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class GlobalValueTest : Spek({
     setup()
 
     val module: Module by memoized()
+
+    group("global value flags") {
+        test("modifying the binary section") {
+            val global = module.addGlobal("test", IntType(1))
+
+            assertNull(global.getSection())
+
+            global.setSection("data")
+
+            assertEquals("data", global.getSection())
+        }
+
+        test("use the symbol visibility") {
+            val global = module.addGlobal("test", IntType(1))
+
+            for (it in Visibility.values()) {
+                global.setVisibility(it)
+
+                assertEquals(it, global.getVisibility())
+            }
+        }
+
+        test("use the storage class") {
+            val global = module.addGlobal("test", IntType(1))
+
+            for (it in DLLStorageClass.values()) {
+                global.setStorageClass(it)
+
+                assertEquals(it, global.getStorageClass())
+            }
+        }
+
+        test("use unnamed address importance") {
+            val global = module.addGlobal("test", IntType(1))
+
+            for (it in UnnamedAddress.values()) {
+                global.setUnnamedAddress(it)
+
+                assertEquals(it, global.getUnnamedAddress())
+            }
+        }
+
+        test("defining alignment of value") {
+            val global = module.addGlobal("test", IntType(1)).apply {
+                setAlignment(16)
+            }
+            val ir = global.getIR().toString()
+
+            assertEquals(16, global.getAlignment())
+            assertTrue { ir.contains("align 16") }
+        }
+    }
+
+    test("forwards declaration of global values") {
+        val global = module.addGlobal("my_external", IntType(32)).apply {
+            setExternallyInitialized(true)
+        }
+
+        assertTrue { global.isDeclaration() }
+    }
+
+    test("using the value type") {
+        val global = module.addGlobal("test", IntType(32))
+        val ptrType = global.getType()
+
+        assertEquals(TypeKind.Pointer, ptrType.getTypeKind())
+
+        val subject = global.getValueType()
+
+        assertEquals(TypeKind.Integer, subject.getTypeKind())
+    }
 
     test("pulling the module from a global value") {
         module.setModuleIdentifier("basic")


### PR DESCRIPTION
There is a significant difference between `GlobalValue.getType` and `GlobalValue.getValueType`. This has been corrected.

The GlobalVariable class now properly extends GlobalValue.

Tests for GlobalValue except for Metadata related ones have been added