### PR TITLE
[dependencies] Upgrade to Kotlin 1.4.0-rc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id "org.jetbrains.dokka" version "0.10.1"
+    id "org.jetbrains.dokka" version "1.4.0-rc"
     id "com.github.johnrengelman.shadow" version "5.2.0"
-    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.0-rc'
 }
 
 repositories {
@@ -32,14 +32,19 @@ tasks.withType(Test).configureEach {
         includeEngines "spek2"
     }
 }
+
+kotlin {
+    explicitApi = 'warning'
+}
+
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0-rc"
     implementation "org.bytedeco:llvm-platform:9.0.0-1.5.2"
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test:1.3.72"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:1.4.0-rc"
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:2.0.11"
     testRuntimeOnly "org.spekframework.spek2:spek-runner-junit5:2.0.11"
-    testRuntimeOnly "org.jetbrains.kotlin:kotlin-reflect:1.3.72"
+    testRuntimeOnly "org.jetbrains.kotlin:kotlin-reflect:1.4.0-rc"
 }
 compileKotlin {
     kotlinOptions {
@@ -49,5 +54,25 @@ compileKotlin {
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+}
+
+dokkaHtml {
+    outputDirectory = "$buildDir/dokka"
+    dokkaSourceSets {
+        configureEach {
+            skipDeprecated = false
+            includeNonPublic = false
+            reportUndocumented = true
+            platform = "JVM"
+            jdkVersion = 8
+            noStdlibLink = false
+            noJdkLink = false
+            sourceLink {
+                path = "./"
+                url = "https://github.com/supergrecko/llvm4kt/tree/master/src/main/kotlin"
+                lineSuffix = "#L"
+            }
+        }
     }
 }

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/BasicBlock.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/BasicBlock.kt
@@ -9,7 +9,7 @@ import org.bytedeco.llvm.global.LLVM
 
 public class BasicBlock internal constructor() : Validatable,
     ContainsReference<LLVMBasicBlockRef> {
-    override var valid = true
+    override var valid: Boolean = true
     public override lateinit var ref: LLVMBasicBlockRef
         internal set
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Instruction.kt
@@ -11,7 +11,7 @@ import org.bytedeco.llvm.global.LLVM
 
 public open class Instruction internal constructor() : Value(),
     DebugLocationValue, Validatable, Cloneable {
-    public override var valid = true
+    public override var valid: Boolean = true
 
     public constructor(llvmRef: LLVMValueRef) : this() {
         ref = llvmRef

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Module.kt
@@ -190,7 +190,9 @@ public class Module internal constructor() : Disposable,
      *
      * @see LLVM.LLVMDumpModule
      */
-    public fun dump() = LLVM.LLVMDumpModule(ref)
+    public fun dump() {
+        LLVM.LLVMDumpModule(ref)
+    }
 
     /**
      * Print the module's IR to a file
@@ -448,7 +450,7 @@ public class Module internal constructor() : Disposable,
      *
      * @see LLVM.LLVMAddGlobal
      */
-    fun addGlobal(
+    public fun addGlobal(
         name: String,
         type: Type,
         addressSpace: Int? = null

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/ModuleFlagEntries.kt
@@ -28,7 +28,10 @@ public class ModuleFlagEntries internal constructor() :
         sizePtr = size
     }
 
-    fun size(): Long {
+    /**
+     * Get the element count in this collection
+     */
+    public fun size(): Long {
         return sizePtr.get()
     }
 

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Opcode.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Opcode.kt
@@ -3,7 +3,7 @@ package dev.supergrecko.vexe.llvm.ir
 import dev.supergrecko.vexe.llvm.internal.contracts.OrderedEnum
 import org.bytedeco.llvm.global.LLVM
 
-enum class Opcode(public override val value: Int) : OrderedEnum<Int> {
+public enum class Opcode(public override val value: Int) : OrderedEnum<Int> {
     Ret(LLVM.LLVMRet),
     Br(LLVM.LLVMBr),
     Switch(LLVM.LLVMSwitch),

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Type.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/Type.kt
@@ -115,15 +115,15 @@ public open class Type internal constructor() : ContainsReference<LLVMTypeRef> {
     /**
      * Get an array type of [size] elements containing elements of this type
      */
-    public fun toArrayType(size: Int) = ArrayType(this, size)
+    public fun toArrayType(size: Int): ArrayType = ArrayType(this, size)
 
     /**
      * Get a vector type of [size] elements containing elements of this type
      */
-    public fun toVectorType(size: Int) = VectorType(this, size)
+    public fun toVectorType(size: Int): VectorType = VectorType(this, size)
     //endregion Typecasting
 
-    companion object {
+    public companion object {
         /**
          * Get the type kind of a type
          *

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/FloatType.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/types/FloatType.kt
@@ -37,7 +37,7 @@ public class FloatType internal constructor() : Type() {
         /**
          * List of all the LLVM floating point types
          */
-        public val kinds = listOf(
+        public val kinds: List<TypeKind> = listOf(
             TypeKind.Half,
             TypeKind.Float,
             TypeKind.Double,

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/IntrinsicFunction.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/IntrinsicFunction.kt
@@ -39,7 +39,7 @@ public class IntrinsicFunction internal constructor() {
      *
      * See https://llvm.org/doxygen/Function_8cpp_source.html#l00549
      */
-    public fun exists() = id != 0
+    public fun exists(): Boolean = id != 0
 
     /**
      * Determine if this intrinsic has overloads or not

--- a/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantPointer.kt
+++ b/src/main/kotlin/dev/supergrecko/vexe/llvm/ir/values/constants/ConstantPointer.kt
@@ -32,7 +32,7 @@ public class ConstantPointer internal constructor() : ConstantValue() {
      *
      * @see LLVM.LLVMConstPointerCast
      */
-    fun getPointerCast(toType: Type): ConstantPointer {
+    public fun getPointerCast(toType: Type): ConstantPointer {
         val value = LLVM.LLVMConstPointerCast(ref, toType.ref)
 
         return ConstantPointer(value)

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/integration/jni/Factorial.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/integration/jni/Factorial.kt
@@ -40,7 +40,7 @@ internal object Factorial : Spek({
         val otherwise = factorial.createBlock("otherwise")
         val exit = factorial.createBlock("exit")
 
-        val builder = Builder().apply {
+        Builder().apply {
             setPositionAtEnd(entry) // enter function
 
             val condition = build().createICmp(

--- a/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/BrInstructionTest.kt
+++ b/src/test/kotlin/dev/supergrecko/vexe/llvm/unit/ir/instructions/BrInstructionTest.kt
@@ -9,6 +9,7 @@ import dev.supergrecko.vexe.llvm.setup
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
 
 internal class BrInstructionTest : Spek({
     setup()
@@ -45,6 +46,7 @@ internal class BrInstructionTest : Spek({
             .createCondBr(condition, then, otherwise)
         val foundCondition = ConstantInt(subject.getCondition().ref)
 
+        assertEquals(condition.ref, foundCondition.ref)
         assertTrue { subject.isConditional() }
     }
 })


### PR DESCRIPTION
This upgrades the kotlin and dokka dependencies to 1.4.0 with the all-new Dokka and the strict api checks for the compiler.