### PR TITLE
[ci] Set up automatic deployment of documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Dokka Deploy
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+          java-package: jdk
+          architecture: x86
+      - name: Build Documentation
+        run: |
+          chmod +x ./gradlew
+          ./gradlew build dokkaHtml
+      - uses: JamesIves/github-pages-deploy-action@3.5.9
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: dokka-autodeploy
+          FOLDER: build/dokka

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -17,6 +17,7 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - name: Run Tests
         run: |
-          gradle clean build test --refresh-dependencies
+          chmod +x ./gradlew
+          ./gradlew clean build test --refresh-dependencies
         env:
           GRADLE_OPTS: -Dorg.gradle.daemon=false


### PR DESCRIPTION
This sets up automatic deployment of our generated dokka build via GitHub actions.

This will build the documentation from source every time something is pushed to master.