### PR TITLE
[api] Give NamedMetadataNode an owner module for Operand APIs

### DIFF
--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
@@ -295,7 +295,7 @@ public class Module internal constructor() : Disposable,
     public fun getNamedMetadataIterator(): NamedMetadataNode.Iterator? {
         val md = LLVM.LLVMGetFirstNamedMetadata(ref)
 
-        return md?.let { NamedMetadataNode.Iterator(it) }
+        return md?.let { NamedMetadataNode.Iterator(this, it) }
     }
 
     /**
@@ -306,7 +306,7 @@ public class Module internal constructor() : Disposable,
     public fun getNamedMetadata(name: String): NamedMetadataNode? {
         val md = LLVM.LLVMGetNamedMetadata(ref, name, name.length.toLong())
 
-        return md?.let { NamedMetadataNode(it) }
+        return md?.let { NamedMetadataNode(it, ref) }
     }
 
     /**
@@ -322,41 +322,7 @@ public class Module internal constructor() : Disposable,
             name.length.toLong()
         )
 
-        return NamedMetadataNode(md)
-    }
-
-    /**
-     * Get the amount of metadata nodes with name [name]
-     *
-     * @see LLVM.LLVMGetNamedMetadataNumOperands
-     */
-    public fun getNamedMetadataOperandCount(name: String): Int {
-        return LLVM.LLVMGetNamedMetadataNumOperands(ref, name)
-    }
-
-    /**
-     * Get the metadata nodes for [name]
-     *
-     * @see LLVM.LLVMGetNamedMetadataOperands
-     */
-    public fun getNamedMetadataOperands(name: String): List<Metadata> {
-        val size = getNamedMetadataOperandCount(name)
-        val ptr = PointerPointer<LLVMValueRef>(size.toLong())
-
-        LLVM.LLVMGetNamedMetadataOperands(ref, name, ptr)
-
-        return ptr.map { Metadata.fromValue(Value(it)) }
-    }
-
-    /**
-     * Add an operand to the given metadata node
-     *
-     * This expects the [operand] to be a Metadata node, disguised in a Value
-     *
-     * @see LLVM.LLVMAddNamedMetadataOperand
-     */
-    public fun addNamedMetadataOperand(name: String, operand: Value) {
-        LLVM.LLVMAddNamedMetadataOperand(ref, name, operand.ref)
+        return NamedMetadataNode(md, ref)
     }
 
     /**

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/NamedMetadataNode.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/NamedMetadataNode.kt
@@ -2,32 +2,94 @@ package io.vexelabs.bitbuilder.llvm.ir
 
 import io.vexelabs.bitbuilder.llvm.internal.contracts.ContainsReference
 import io.vexelabs.bitbuilder.llvm.internal.contracts.PointerIterator
+import io.vexelabs.bitbuilder.llvm.internal.util.map
+import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.javacpp.SizeTPointer
+import org.bytedeco.llvm.LLVM.LLVMModuleRef
 import org.bytedeco.llvm.LLVM.LLVMNamedMDNodeRef
+import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class NamedMetadataNode internal constructor() :
-    ContainsReference<LLVMNamedMDNodeRef> {
-    public override lateinit var ref: LLVMNamedMDNodeRef
-        internal set
-
-    public constructor(llvmRef: LLVMNamedMDNodeRef) : this() {
-        ref = llvmRef
-    }
-
-    //region Core::Modules
+/**
+ * Represents a Named Metadata Node which is a top level metadata node in a
+ * [Module]
+ *
+ * A named metadata node is essentially an array of other [Metadata] nodes.
+ * These are named "operands" in the LLVM-C API and you can modify this list
+ * with the [getOperands], [addOperand], [getOrCreateOperand] and
+ * [getOperandCount] member methods.
+ *
+ * [LLVM Documentation](https://llvm.org/docs/LangRef.html#named-metadata)
+ */
+public class NamedMetadataNode public constructor(
+    public override val ref: LLVMNamedMDNodeRef,
+    public val owner: LLVMModuleRef
+) : ContainsReference<LLVMNamedMDNodeRef> {
     /**
-     * Get the name of this metadata node
+     * Get the name of this named metadata node
+     *
+     * This name is immutable which means we can get it by lazy like this.
+     */
+    private val name: String by lazy { getNodeName() }
+
+    /**
+     * Retrieve the of this metadata node
+     *
+     * This is only ran once per named metadata node to cache the value into
+     * [name]
      *
      * @see LLVM.LLVMGetNamedMetadataName
      */
-    public fun getName(): String {
+    private fun getNodeName(): String {
         val len = SizeTPointer(0)
         val ptr = LLVM.LLVMGetNamedMetadataName(ref, len)
 
         len.deallocate()
 
         return ptr.string
+    }
+
+    //region Core::Modules
+    /**
+     * Get all the operands in this list
+     *
+     * @see LLVM.LLVMGetNamedMetadataOperands
+     */
+    public fun getOperands(): List<Metadata> {
+        val size = getOperandCount()
+        val ptr = PointerPointer<LLVMValueRef>(size.toLong())
+
+        LLVM.LLVMGetNamedMetadataOperands(owner, name, ptr)
+
+        return ptr.map { Metadata.fromValue(Value(it)) }
+    }
+
+    /**
+     * Get the amount of operands in this list
+     *
+     * @see LLVM.LLVMGetNamedMetadataNumOperands
+     */
+    public fun getOperandCount(): Int {
+        return LLVM.LLVMGetNamedMetadataNumOperands(owner, name)
+    }
+
+    /**
+     * Add a metadata operand to this list
+     *
+     * LLVM-C expects a metadata node as value (see [Metadata.asValue] for
+     * this method, but because we know we actually require a metadata node,
+     * we can do the conversion ourself, giving the user better type safety.
+     *
+     * This will by default use the context the [owner] module resides in,
+     * but this can be changed by passing the [withContext] parameter.
+     *
+     * @see LLVM.LLVMAddNamedMetadataOperand
+     */
+    public fun addOperand(metadata: Metadata, withContext: Context? = null) {
+        val ctx = withContext ?: Module(owner).getContext()
+        val value = metadata.asValue(ctx)
+
+        LLVM.LLVMAddNamedMetadataOperand(owner, name, value.ref)
     }
     //endregion Core::Modules
 
@@ -36,10 +98,10 @@ public class NamedMetadataNode internal constructor() :
      *
      * @see [PointerIterator]
      */
-    public class Iterator(ref: LLVMNamedMDNodeRef) :
+    public class Iterator(owner: Module, ref: LLVMNamedMDNodeRef) :
         PointerIterator<NamedMetadataNode, LLVMNamedMDNodeRef>(
             start = ref,
             yieldNext = { LLVM.LLVMGetNextNamedMetadata(it) },
-            apply = { NamedMetadataNode(it) }
+            apply = { NamedMetadataNode(it, owner.ref) }
         )
 }

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/NamedMetadataNode.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/NamedMetadataNode.kt
@@ -16,7 +16,7 @@ import org.bytedeco.llvm.global.LLVM
  *
  * A named metadata node is essentially an array of other [Metadata] nodes.
  * These are named "operands" in the LLVM-C API and you can modify this list
- * with the [getOperands], [addOperand], [getOrCreateOperand] and
+ * with the [getOperands], [addOperand] and
  * [getOperandCount] member methods.
  *
  * [LLVM Documentation](https://llvm.org/docs/LangRef.html#named-metadata)
@@ -30,7 +30,7 @@ public class NamedMetadataNode public constructor(
      *
      * This name is immutable which means we can get it by lazy like this.
      */
-    private val name: String by lazy { getNodeName() }
+    public val name: String by lazy { getNodeName() }
 
     /**
      * Retrieve the of this metadata node

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/NamedMetadataTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/NamedMetadataTest.kt
@@ -14,60 +14,28 @@ internal object NamedMetadataTest : Spek({
 
     val module: Module by memoized()
 
-    group("getting metadata from a module") {
-        test("a module without metadata does not have a first or last") {
-            val iter = module.getNamedMetadataIterator()
+    test("the name of a node matches") {
+        val metadata = module.getOrCreateNamedMetadata("test")
 
-            assertNull(iter)
-        }
-
-        test("a module with metadata can use the iterator") {
-            module.getOrCreateNamedMetadata("one")
-            module.getOrCreateNamedMetadata("two")
-
-            val iter = module.getNamedMetadataIterator()
-
-            assertNotNull(iter)
-            assertTrue { iter.hasNext() }
-
-            val first = iter.next()
-
-            assertTrue { iter.hasNext() }
-
-            val second = iter.next()
-
-            assertEquals("one", first.getName())
-            assertEquals("two", second.getName())
-        }
-
-        test("finding a metadata node by name") {
-            module.getOrCreateNamedMetadata("metadata")
-
-            val subject = module.getNamedMetadata("metadata")
-
-            assertNotNull(subject)
-            assertEquals("metadata", subject.getName())
-        }
+        assertEquals("test", metadata.name)
     }
 
-    group("assigning values to the metadata nodes") {
-        test("a node without any values has a size of 0") {
-            module.getOrCreateNamedMetadata("metadata")
+    group("fetching and creating operands for a node") {
+        test("a fresh node does not have any operands") {
+            val metadata = module.getOrCreateNamedMetadata("test")
 
-            assertEquals(0, module.getNamedMetadataOperandCount("metadata"))
+            assertEquals(0, metadata.getOperandCount())
+            assertTrue { metadata.getOperands().isEmpty() }
         }
 
-        test("retrieving the operands from the metadata") {
-            val operand = Metadata("meta").asValue()
+        test("adding an operand to a node") {
+            val metadata = Metadata("never")
+            val node = module.getOrCreateNamedMetadata("test").also {
+                it.addOperand(metadata)
+            }
 
-            module.getOrCreateNamedMetadata("metadata")
-            module.addNamedMetadataOperand("metadata", operand)
-
-            assertEquals(1, module.getNamedMetadataOperandCount("metadata"))
-
-            val subject = module.getNamedMetadataOperands("metadata")
-
-            assertNotNull(subject)
+            assertEquals(1, node.getOperandCount())
+            // TODO: Compare nodes
         }
     }
 })


### PR DESCRIPTION
These APIs were previously in the Module implementation because that's how LLVM-C treats them. This change moves them where it makes sense logically.
