### PR TITLE
[refactor] Make Metadata APIs mirror the C++ API

### DIFF
--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Metadata.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Metadata.kt
@@ -8,70 +8,79 @@ import org.bytedeco.llvm.LLVM.LLVMMetadataRef
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
-public class Metadata internal constructor() :
-    ContainsReference<LLVMMetadataRef> {
-    public override lateinit var ref: LLVMMetadataRef
+public sealed class Metadata : ContainsReference<LLVMMetadataRef> {
+    public final override lateinit var ref: LLVMMetadataRef
         internal set
 
-    public constructor(llvmRef: LLVMMetadataRef) : this() {
+    /**
+     * Represent a [MetadataNode] which has been cast to a [Value]
+     */
+    public class MetadataAsValue(ref: LLVMValueRef) : Value(ref)
+
+    /**
+     * Represent a [Value] which has been cast to a [MetadataNode]
+     */
+    public class ValueAsMetadata(ref: LLVMMetadataRef) : MetadataNode(ref)
+
+    /**
+     * Cast this Metadata node to a value
+     *
+     * @see LLVM.LLVMMetadataAsValue
+     */
+    public fun toValue(
+        withContext: Context = Context.getGlobalContext()
+    ): MetadataAsValue {
+        val md = LLVM.LLVMMetadataAsValue(withContext.ref, ref)
+
+        return MetadataAsValue(md)
+    }
+
+    public companion object {
+        /**
+         * Cast a value to a [MetadataNode]
+         *
+         * @see LLVM.LLVMValueAsMetadata
+         */
+        public fun fromValue(value: Value): ValueAsMetadata {
+            val md = LLVM.LLVMValueAsMetadata(value.ref)
+
+            return ValueAsMetadata(md)
+        }
+
+        /**
+         * Cast this Metadata node to a value
+         *
+         * LLVM-C accepts a [LLVMValueRef] for this so the node is cast to a
+         * [Metadata.MetadataAsValue]. This requires a context. Set the context
+         * which this should use with [withContext]
+         *
+         * @see LLVM.LLVMMetadataAsValue
+         * @see LLVM.LLVMMetadataAsValue
+         */
+        public fun toValue(
+            metadata: Metadata,
+            withContext: Context = Context.getGlobalContext()
+        ): MetadataAsValue = metadata.toValue(withContext)
+    }
+}
+
+public class MetadataString : Metadata {
+    public constructor(llvmRef: LLVMMetadataRef) {
         ref = llvmRef
     }
 
     //region Core::Metadata
-    /**
-     * Create a string metadata node
-     *
-     * @see LLVM.LLVMMDStringInContext2
-     */
     public constructor(
-        string: String,
+        data: String,
         context: Context = Context.getGlobalContext()
-    ) : this() {
+    ) {
         ref = LLVM.LLVMMDStringInContext2(
             context.ref,
-            string,
-            string.length.toLong()
+            data,
+            data.length.toLong()
         )
     }
-
-    /**
-     * Create a metadata node
-     *
-     * @see LLVM.LLVMMDNodeInContext2
-     */
-    public constructor(
-        operands: List<Metadata>,
-        context: Context = Context.getGlobalContext()
-    ) : this() {
-        val ptr = PointerPointer(*operands.map { it.ref }.toTypedArray())
-        ref = LLVM.LLVMMDNodeInContext2(
-            context.ref,
-            ptr,
-            operands.size.toLong()
-        )
-    }
-
-    /**
-     * Create a metadata node from a value
-     *
-     * @see LLVM.LLVMValueAsMetadata
-     */
-    public constructor(value: Value) : this() {
-        ref = LLVM.LLVMValueAsMetadata(value.ref)
-    }
-
-    /**
-     * Get the current metadata as value
-     *
-     * @see LLVM.LLVMMetadataAsValue
-     */
-    public fun asValue(
-        context: Context = Context.getGlobalContext()
-    ): Value {
-        val v = LLVM.LLVMMetadataAsValue(context.ref, ref)
-
-        return Value(v)
-    }
+    //endregion Core::Metadata
 
     /**
      * Get the string from a MDString node
@@ -82,52 +91,68 @@ public class Metadata internal constructor() :
         context: Context = Context.getGlobalContext()
     ): String {
         val len = IntPointer(0)
-        val ptr = LLVM.LLVMGetMDString(asValue(context).ref, len)
+        val ptr = LLVM.LLVMGetMDString(toValue(context).ref, len)
 
         len.deallocate()
 
         return ptr.string
     }
+}
+
+public open class MetadataNode : Metadata {
+    public constructor(llvmRef: LLVMMetadataRef) {
+        ref = llvmRef
+    }
+
+    //region Core::Metadata
+    public constructor(
+        values: List<Metadata>,
+        context: Context = Context.getGlobalContext()
+    ) {
+        val ptr = PointerPointer(*values.map { it.ref }.toTypedArray())
+        ref = LLVM.LLVMMDNodeInContext2(
+            context.ref,
+            ptr,
+            values.size.toLong()
+        )
+    }
 
     /**
      * Get the amount of operands in a metadata node
      *
+     * LLVM-C accepts a [LLVMValueRef] for this so the node is cast to a
+     * [Metadata.MetadataAsValue]. This requires a context. Set the context
+     * which this should use with [withContext]
+     *
      * @see LLVM.LLVMGetMDNodeNumOperands
      */
     public fun getOperandCount(
-        context: Context = Context.getGlobalContext()
+        withContext: Context = Context.getGlobalContext()
     ): Int {
-        return LLVM.LLVMGetMDNodeNumOperands(asValue(context).ref)
+        return LLVM.LLVMGetMDNodeNumOperands(toValue(withContext).ref)
     }
 
     /**
      * Get the operands from a metadata node
      *
+     * LLVM-C accepts a [LLVMValueRef] for this so the node is cast to a
+     * [Metadata.MetadataAsValue]. This requires a context. Set the context
+     * which this should use with [withContext]
+     *
      * @see LLVM.LLVMGetMDNodeOperands
      */
     public fun getOperands(
-        context: Context = Context.getGlobalContext()
+        withContext: Context = Context.getGlobalContext()
     ): List<Value> {
         val count = getOperandCount().toLong()
         val ptr = PointerPointer<LLVMValueRef>(count)
 
         LLVM.LLVMGetMDNodeOperands(
-            asValue(context).ref,
+            toValue(withContext).ref,
             ptr
         )
 
         return ptr.map { Value(it) }
-    }
-
-    public companion object {
-        /**
-         * Create a metadata node from a value
-         *
-         * @see LLVM.LLVMValueAsMetadata
-         */
-        public fun fromValue(value: Value): Metadata {
-            return Metadata(value)
-        }
     }
     //endregion Core::Metadata
 }

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/NamedMetadataNode.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/NamedMetadataNode.kt
@@ -87,7 +87,7 @@ public class NamedMetadataNode public constructor(
      */
     public fun addOperand(metadata: Metadata, withContext: Context? = null) {
         val ctx = withContext ?: Module(owner).getContext()
-        val value = metadata.asValue(ctx)
+        val value = metadata.toValue(ctx)
 
         LLVM.LLVMAddNamedMetadataOperand(owner, name, value.ref)
     }

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/InstructionTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/InstructionTest.kt
@@ -3,6 +3,7 @@ package io.vexelabs.bitbuilder.llvm.unit.ir
 import io.vexelabs.bitbuilder.llvm.ir.Builder
 import io.vexelabs.bitbuilder.llvm.ir.Context
 import io.vexelabs.bitbuilder.llvm.ir.Metadata
+import io.vexelabs.bitbuilder.llvm.ir.MetadataString
 import io.vexelabs.bitbuilder.llvm.ir.Module
 import io.vexelabs.bitbuilder.llvm.ir.Opcode
 import io.vexelabs.bitbuilder.llvm.ir.types.FunctionType
@@ -34,7 +35,7 @@ internal object InstructionTest : Spek({
             val inst = builder.build().createRetVoid().apply {
                 setMetadata(
                     "range",
-                    Metadata("yes").asValue(context)
+                    MetadataString("yes").toValue(context)
                 )
             }
             val subject = inst.getMetadata("range")
@@ -47,7 +48,7 @@ internal object InstructionTest : Spek({
             val inst = builder.build().createRetVoid().apply {
                 setMetadata(
                     "range",
-                    Metadata("yes").asValue(context)
+                    MetadataString("yes").toValue(context)
                 )
             }
             val bucket = inst.getAllMetadataExceptDebugLocations()

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/MetadataTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/MetadataTest.kt
@@ -1,0 +1,65 @@
+package io.vexelabs.bitbuilder.llvm.unit.ir
+
+import io.vexelabs.bitbuilder.llvm.ir.Metadata
+import io.vexelabs.bitbuilder.llvm.ir.MetadataNode
+import io.vexelabs.bitbuilder.llvm.ir.MetadataString
+import io.vexelabs.bitbuilder.llvm.ir.types.IntType
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
+import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal object MetadataTest : Spek({
+    group("casting values to and from metadata") {
+        test("any value may be used as metadata") {
+            val value = ConstantInt(IntType(32), 1000)
+            val metadata = Metadata.fromValue(value)
+
+            assertTrue { metadata.isNode() }
+        }
+
+        test("metadata may be cast to values") {
+            val str = MetadataString("hello world")
+            val node = MetadataNode(listOf(MetadataString("hello")))
+            val strValue = str.toValue()
+            val strNode = node.toValue()
+
+            assertTrue { strValue.isMetadataString() }
+            assertTrue { strNode.isMetadataNode() }
+        }
+    }
+
+    test("retrieving the string from a metadatastring") {
+        val metadata = MetadataString("hello world")
+
+        assertEquals("hello world", metadata.getString())
+    }
+
+    test("a fresh node has zero operands") {
+        val metadata = MetadataNode(listOf())
+
+        assertEquals(0, metadata.getOperandCount())
+        assertTrue { metadata.getOperands().isEmpty() }
+    }
+
+    test("fetching operands from a metadata node") {
+        val child = MetadataString("hello")
+        val node = MetadataNode(listOf(child))
+        val operands = node.getOperands()
+
+        assertEquals(1, node.getOperandCount())
+        assertEquals(1, operands.size)
+
+        val first = operands.first()
+
+        assertTrue { first.isMetadataString() }
+
+        val metadata = Metadata.fromValue(first)
+
+        assertTrue { metadata.isString() }
+
+        val string = MetadataString(metadata.ref)
+
+        assertEquals("hello", string.getString())
+    }
+})

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/ModuleTest.kt
@@ -3,6 +3,7 @@ package io.vexelabs.bitbuilder.llvm.unit.ir
 import io.vexelabs.bitbuilder.llvm.TestUtils
 import io.vexelabs.bitbuilder.llvm.ir.Context
 import io.vexelabs.bitbuilder.llvm.ir.Metadata
+import io.vexelabs.bitbuilder.llvm.ir.MetadataString
 import io.vexelabs.bitbuilder.llvm.ir.Module
 import io.vexelabs.bitbuilder.llvm.ir.ModuleFlagBehavior
 import io.vexelabs.bitbuilder.llvm.ir.types.IntType
@@ -91,7 +92,7 @@ internal object ModuleTest : Spek({
 
     group("module flag entries") {
         test("setting a metadata flag and finding it") {
-            val md = Metadata("example")
+            val md = MetadataString("example")
             module.addModuleFlag(ModuleFlagBehavior.Override, "example", md)
 
             val subject = module.getModuleFlag("example")
@@ -100,7 +101,7 @@ internal object ModuleTest : Spek({
         }
 
         test("retrieving all the module flags") {
-            val md = Metadata("example")
+            val md = MetadataString("example")
             module.addModuleFlag(ModuleFlagBehavior.Override, "example", md)
 
             val subject = module.getModuleFlags()

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/NamedMetadataTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/NamedMetadataTest.kt
@@ -1,6 +1,7 @@
 package io.vexelabs.bitbuilder.llvm.unit.ir
 
 import io.vexelabs.bitbuilder.llvm.ir.Metadata
+import io.vexelabs.bitbuilder.llvm.ir.MetadataString
 import io.vexelabs.bitbuilder.llvm.ir.Module
 import io.vexelabs.bitbuilder.llvm.setup
 import kotlin.test.assertEquals
@@ -29,13 +30,14 @@ internal object NamedMetadataTest : Spek({
         }
 
         test("adding an operand to a node") {
-            val metadata = Metadata("never")
+            val metadata = MetadataString("never")
             val node = module.getOrCreateNamedMetadata("test").also {
                 it.addOperand(metadata)
             }
+            val operands = node.getOperands()
 
             assertEquals(1, node.getOperandCount())
-            // TODO: Compare nodes
+            assertEquals(1, operands.size)
         }
     }
 })


### PR DESCRIPTION
LLVM allows for casting between Metadata and Values and uses the helper classes ValueAsMetadata and MetadataAsValue to mark objects which have gone through this cast. Our API will also do this now to be able to differentiate between Metadata values and other values.

Tests have been added for all the Metadata APIs