### PR TITLE
[llvm] Upgrade to LLVM 10.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0-rc")
-    implementation("org.bytedeco:llvm-platform:9.0.0-1.5.2")
+    implementation("org.bytedeco:llvm-platform:10.0.0-1.5.3")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.4.0-rc")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:2.0.11")

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Comdat.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Comdat.kt
@@ -1,13 +1,13 @@
 package io.vexelabs.bitbuilder.llvm.ir
 
 import io.vexelabs.bitbuilder.llvm.internal.contracts.ContainsReference
-import org.bytedeco.llvm.LLVM.LLVMComdat
+import org.bytedeco.llvm.LLVM.LLVMComdatRef
 
-public class Comdat internal constructor() : ContainsReference<LLVMComdat> {
-    public override lateinit var ref: LLVMComdat
+public class Comdat internal constructor() : ContainsReference<LLVMComdatRef> {
+    public override lateinit var ref: LLVMComdatRef
         internal set
 
-    public constructor(comdat: LLVMComdat) : this() {
+    public constructor(comdat: LLVMComdatRef) : this() {
         ref = comdat
     }
 }

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Flags.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Flags.kt
@@ -129,10 +129,9 @@ public enum class AtomicRMWBinaryOperation(public override val value: Int) :
     Max(LLVM.LLVMAtomicRMWBinOpMax),
     Min(LLVM.LLVMAtomicRMWBinOpMin),
     UMax(LLVM.LLVMAtomicRMWBinOpUMax),
-    UMin(LLVM.LLVMAtomicRMWBinOpUMin);
-    // TODO: LLVM 10
-    // LLVMAtomicRMWBinOpFAdd(LLVM.LLVMAtomicRMWBinOpFAdd),
-    // LLVMAtomicRMWBinOpFSub(LLVM.LLVMAtomicRMWBinOpFSub)
+    UMin(LLVM.LLVMAtomicRMWBinOpUMin),
+    LLVMAtomicRMWBinOpFAdd(LLVM.LLVMAtomicRMWBinOpFAdd),
+    LLVMAtomicRMWBinOpFSub(LLVM.LLVMAtomicRMWBinOpFSub);
 
     public companion object :
         ForeignEnum.CompanionBase<Int, AtomicRMWBinaryOperation> {

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/FunctionValue.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/FunctionValue.kt
@@ -150,6 +150,7 @@ public open class FunctionValue internal constructor() : Value(),
     //endregion Core::Values::Constants::FunctionValues::FunctionParameters
 
     //region Core::Values::Constants::FunctionValues::IndirectFunctions
+    // TODO: Move to IndirectFunction.kt
     /**
      * Get the indirect resolver if it has been set
      *
@@ -172,6 +173,8 @@ public open class FunctionValue internal constructor() : Value(),
 
     /**
      * Make this indirect function global in the given [module]
+     *
+     * TODO: Move to Module.kt
      *
      * @see LLVM.LLVMAddGlobalIFunc
      */

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/IndirectFunction.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/IndirectFunction.kt
@@ -41,6 +41,7 @@ public class IndirectFunction internal constructor() : FunctionValue() {
     }
 
     public companion object {
+        // TODO: Move to Module.kt
         @JvmStatic
         public fun fromModule(module: Module, name: String): IndirectFunction {
             val fn = LLVM.LLVMGetNamedGlobalIFunc(


### PR DESCRIPTION
Upgrades the LLVM dependency to 10.0.0

Turns out the JavaCPP LLVM 10 bindings are complete and we do not need to create our own JNI bindings like planned out in #166.

Closes #166 
Closes #98 