### PR TITLE
[api/ifunc] Move IndirectFunction lookup into Module

### DIFF
--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
@@ -634,6 +634,17 @@ public class Module internal constructor() : Disposable,
 
         return IndirectFunction(func)
     }
+
+    /**
+     * Get the start of the global indirect function iterator
+     *
+     * @see LLVM.LLVMGetFirstGlobalIFunc
+     */
+    public fun getGlobalIndirectFunctionIterator(): IndirectFunction.Iterator? {
+        val fn = LLVM.LLVMGetFirstGlobalIFunc(ref)
+
+        return fn?.let { IndirectFunction.Iterator(fn) }
+    }
     //endregion Core::Values::Constants::FunctionValues::IndirectFunctions
 
     public override fun dispose() {

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
@@ -13,6 +13,7 @@ import io.vexelabs.bitbuilder.llvm.ir.types.StructType
 import io.vexelabs.bitbuilder.llvm.ir.values.FunctionValue
 import io.vexelabs.bitbuilder.llvm.ir.values.GlobalAlias
 import io.vexelabs.bitbuilder.llvm.ir.values.GlobalVariable
+import io.vexelabs.bitbuilder.llvm.ir.values.IndirectFunction
 import io.vexelabs.bitbuilder.llvm.support.MemoryBuffer
 import io.vexelabs.bitbuilder.llvm.support.VerifierFailureAction
 import java.io.File
@@ -591,6 +592,49 @@ public class Module internal constructor() : Disposable,
         }
     }
     //endregion ExecutionEngine
+
+    //region Core::Values::Constants::FunctionValues::IndirectFunctions
+    /**
+     * Looks up a globally available, named IFunc
+     *
+     * @see LLVM.LLVMGetNamedGlobalIFunc
+     */
+    public fun getGlobalIndirectFunction(name: String): IndirectFunction? {
+        val func = LLVM.LLVMGetNamedGlobalIFunc(
+            ref,
+            name,
+            name.length.toLong()
+        )
+
+        return func?.let { IndirectFunction(it) }
+    }
+
+    /**
+     * Create a new Global indirect function with the provided [resolver]
+     *
+     * This registers a new ifunc with the provided [name] and stores it in
+     * the provided [addressSpace]
+     *
+     * @see LLVM.LLVMAddGlobalIFunc
+     */
+    public fun addGlobalIndirectFunction(
+        name: String,
+        signature: FunctionType,
+        resolver: FunctionValue,
+        addressSpace: Int
+    ): IndirectFunction {
+        val func = LLVM.LLVMAddGlobalIFunc(
+            ref,
+            name,
+            name.length.toLong(),
+            signature.ref,
+            addressSpace,
+            resolver.ref
+        )
+
+        return IndirectFunction(func)
+    }
+    //endregion Core::Values::Constants::FunctionValues::IndirectFunctions
 
     public override fun dispose() {
         require(valid) { "Cannot dispose object twice" }

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/FunctionValue.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/FunctionValue.kt
@@ -143,6 +143,8 @@ public open class FunctionValue internal constructor() : Value(),
 
     /**
      * Set the parameter alignment for parameter [value]
+     *
+     * @see LLVM.LLVMSetParamAlignment
      */
     public fun setParameterAlignment(value: Value, align: Int) {
         LLVM.LLVMSetParamAlignment(value.ref, align)
@@ -150,7 +152,6 @@ public open class FunctionValue internal constructor() : Value(),
     //endregion Core::Values::Constants::FunctionValues::FunctionParameters
 
     //region Core::Values::Constants::FunctionValues::IndirectFunctions
-    // TODO: Move to IndirectFunction.kt
     /**
      * Get the indirect resolver if it has been set
      *
@@ -169,32 +170,6 @@ public open class FunctionValue internal constructor() : Value(),
      */
     public fun setIndirectResolver(function: IndirectFunction) {
         LLVM.LLVMSetGlobalIFuncResolver(ref, function.ref)
-    }
-
-    /**
-     * Make this indirect function global in the given [module]
-     *
-     * TODO: Move to Module.kt
-     *
-     * @see LLVM.LLVMAddGlobalIFunc
-     */
-    public fun makeGlobal(
-        module: Module,
-        name: String,
-        type: FunctionType,
-        addressSpace: Int,
-        resolver: FunctionValue
-    ): IndirectFunction {
-        val indirect = LLVM.LLVMAddGlobalIFunc(
-            module.ref,
-            name,
-            name.length.toLong(),
-            type.ref,
-            addressSpace,
-            resolver.ref
-        )
-
-        return IndirectFunction(indirect)
     }
     //endregion Core::Values::Constants::FunctionValues::IndirectFunctions
 

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/IndirectFunction.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/IndirectFunction.kt
@@ -1,5 +1,6 @@
 package io.vexelabs.bitbuilder.llvm.ir.values
 
+import io.vexelabs.bitbuilder.llvm.internal.contracts.PointerIterator
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
@@ -30,4 +31,16 @@ public class IndirectFunction internal constructor() : FunctionValue() {
         LLVM.LLVMRemoveGlobalIFunc(ref)
     }
     //endregion Core::Values::Constants::FunctionValues::IndirectFunctions
+
+    /**
+     * Class to perform iteration over basic blocks
+     *
+     * @see [PointerIterator]
+     */
+    public class Iterator(ref: LLVMValueRef) :
+        PointerIterator<IndirectFunction, LLVMValueRef>(
+            start = ref,
+            yieldNext = { LLVM.LLVMGetNextGlobalIFunc(it) },
+            apply = { IndirectFunction(it) }
+        )
 }

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/IndirectFunction.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/IndirectFunction.kt
@@ -1,6 +1,5 @@
 package io.vexelabs.bitbuilder.llvm.ir.values
 
-import io.vexelabs.bitbuilder.llvm.ir.Module
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import org.bytedeco.llvm.global.LLVM
 
@@ -10,15 +9,6 @@ public class IndirectFunction internal constructor() : FunctionValue() {
     }
 
     //region Core::Values::Constants::FunctionValues::IndirectFunctions
-    /**
-     * Convert a regular function to an indirect one
-     *
-     * Can be used for assigning [FunctionValue.getIndirectResolver]
-     */
-    public constructor(function: FunctionValue) : this() {
-        ref = function.ref
-    }
-
     /**
      * Remove a global indirect function from its parent module and delete it.
      *
@@ -38,26 +28,6 @@ public class IndirectFunction internal constructor() : FunctionValue() {
      */
     public fun remove() {
         LLVM.LLVMRemoveGlobalIFunc(ref)
-    }
-
-    public companion object {
-        // TODO: Move to Module.kt
-        @JvmStatic
-        public fun fromModule(module: Module, name: String): IndirectFunction {
-            val fn = LLVM.LLVMGetNamedGlobalIFunc(
-                module.ref,
-                name,
-                name.length.toLong()
-            )
-
-            return if (fn == null) {
-                throw IllegalArgumentException(
-                    "Function $name could not be found in module."
-                )
-            } else {
-                IndirectFunction(fn)
-            }
-        }
     }
     //endregion Core::Values::Constants::FunctionValues::IndirectFunctions
 }


### PR DESCRIPTION
The creation and searching for GlobalIndirectFunctions were placed incorrectly. These are all functions which belong to a Module which means they should be members of the Module class.

The FunctionValue constructor for IndirectFunction has been removed as this is not how we should make IndirectFunctions, we should use the addGlobalIndirectFunction method for the Module.