### PR TITLE
[api] Add Comdat APIs

### DIFF
--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Comdat.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Comdat.kt
@@ -1,7 +1,9 @@
 package io.vexelabs.bitbuilder.llvm.ir
 
 import io.vexelabs.bitbuilder.llvm.internal.contracts.ContainsReference
+import io.vexelabs.bitbuilder.llvm.internal.contracts.ForeignEnum
 import org.bytedeco.llvm.LLVM.LLVMComdatRef
+import org.bytedeco.llvm.global.LLVM
 
 public class Comdat internal constructor() : ContainsReference<LLVMComdatRef> {
     public override lateinit var ref: LLVMComdatRef
@@ -9,5 +11,40 @@ public class Comdat internal constructor() : ContainsReference<LLVMComdatRef> {
 
     public constructor(comdat: LLVMComdatRef) : this() {
         ref = comdat
+    }
+
+    /**
+     * Get the selection kind of this comdat
+     *
+     * @see LLVM.LLVMGetComdatSelectionKind
+     */
+    public fun getSelectionKind(): SelectionKind {
+        val kind = LLVM.LLVMGetComdatSelectionKind(ref)
+
+        return SelectionKind[kind]
+    }
+
+    /**
+     * Set the selection kind of this comdat
+     *
+     * @see LLVM.LLVMSetComdatSelectionKind
+     */
+    public fun setSelectionKind(kind: SelectionKind) {
+        LLVM.LLVMSetComdatSelectionKind(ref, kind.value)
+    }
+
+    public enum class SelectionKind(public override val value: Int) :
+        ForeignEnum<Int> {
+        Any(LLVM.LLVMAnyComdatSelectionKind),
+        ExactMatch(LLVM.LLVMExactMatchComdatSelectionKind),
+        Largest(LLVM.LLVMLargestComdatSelectionKind),
+        NoDuplicates(LLVM.LLVMNoDuplicatesComdatSelectionKind),
+        SameSize(LLVM.LLVMSameSizeComdatSelectionKind);
+
+        public companion object : ForeignEnum.CompanionBase<Int, SelectionKind> {
+            public override val map: Map<Int, SelectionKind> by lazy {
+                values().associateBy(SelectionKind::value)
+            }
+        }
     }
 }

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Module.kt
@@ -647,6 +647,17 @@ public class Module internal constructor() : Disposable,
     }
     //endregion Core::Values::Constants::FunctionValues::IndirectFunctions
 
+    /**
+     * Get the comdat with the specified name or create it if it does not exist
+     *
+     * @see LLVM.LLVMGetOrInsertComdat
+     */
+    public fun getOrCreateComdat(name: String): Comdat {
+        val comdat = LLVM.LLVMGetOrInsertComdat(ref, name)
+
+        return Comdat(comdat)
+    }
+
     public override fun dispose() {
         require(valid) { "Cannot dispose object twice" }
 

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/GlobalValue.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/GlobalValue.kt
@@ -2,6 +2,7 @@ package io.vexelabs.bitbuilder.llvm.ir.values
 
 import io.vexelabs.bitbuilder.llvm.internal.contracts.ForeignEnum
 import io.vexelabs.bitbuilder.llvm.internal.util.fromLLVMBool
+import io.vexelabs.bitbuilder.llvm.ir.Comdat
 import io.vexelabs.bitbuilder.llvm.ir.DLLStorageClass
 import io.vexelabs.bitbuilder.llvm.ir.Metadata
 import io.vexelabs.bitbuilder.llvm.ir.MetadataEntries
@@ -217,6 +218,26 @@ public open class GlobalValue internal constructor() : ConstantValue() {
         return MetadataEntries(entries, ptr)
     }
     //endregion Core::Values::Constants::GlobalValues
+
+    /**
+     * Get the comdat assigned to this value
+     *
+     * @see LLVM.LLVMGetComdat
+     */
+    public fun getComdat(): Comdat? {
+        val comdat = LLVM.LLVMGetComdat(ref)
+
+        return comdat?.let { Comdat(it) }
+    }
+
+    /**
+     * Set the comdat for this value
+     *
+     * @see LLVM.LLVMSetComdat
+     */
+    public fun setComdat(comdat: Comdat) {
+        LLVM.LLVMSetComdat(ref, comdat.ref)
+    }
 
     public enum class Linkage(public override val value: Int) : ForeignEnum<Int> {
         External(LLVM.LLVMExternalLinkage),

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/ComdatTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/ComdatTest.kt
@@ -1,0 +1,32 @@
+package io.vexelabs.bitbuilder.llvm.unit.ir
+
+import io.vexelabs.bitbuilder.llvm.ir.Comdat
+import io.vexelabs.bitbuilder.llvm.ir.Module
+import io.vexelabs.bitbuilder.llvm.ir.types.IntType
+import io.vexelabs.bitbuilder.llvm.setup
+import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+internal object ComdatTest : Spek({
+    setup()
+
+    val module: Module by memoized()
+
+    test("creating a comdat and setting its selection kind") {
+        val comdat = module.getOrCreateComdat("hello")
+        val value = module.addGlobal("test", IntType(32))
+
+        assertNull(value.getComdat())
+
+        value.setComdat(comdat)
+
+        assertNotNull(value.getComdat())
+
+        for (i in Comdat.SelectionKind.values()) {
+            comdat.setSelectionKind(i)
+            assertEquals(i, comdat.getSelectionKind())
+        }
+    }
+})

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/ModuleTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/ModuleTest.kt
@@ -167,14 +167,14 @@ internal object ModuleTest : Spek({
         assertEquals(type.ref, subject?.ref)
     }
 
-    group("verification") {
-        test("verification of a valid module") {
+    group("verification of a module's ir") {
+        test("using a valid module") {
             val success = module.verify(VerifierFailureAction.PrintMessage)
 
             assertTrue { success }
         }
 
-        test("invalid module") {
+        test("using an invalid module") {
             module.addGlobal("Nothing", VoidType()).apply {
                 setInitializer(ConstantInt(IntType(32), 100))
             }
@@ -183,5 +183,12 @@ internal object ModuleTest : Spek({
 
             assertFalse { success }
         }
+    }
+
+    test("colliding comdat names returns the original") {
+        val original = module.getOrCreateComdat("hello")
+        val subject = module.getOrCreateComdat("hello")
+
+        assertEquals(original.ref, subject.ref)
     }
 })


### PR DESCRIPTION
This patch adds the Comdat LLVM APIs for Global Values, tests have also been added.

The enum LLVMComdatSelectionKind has been added as `Comdat.SelectionKind`.

Retrieved from https://llvm.org/doxygen/c_2Comdat_8h.html