### PR TITLE
[ci] Remove setup-java from ci pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,13 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          java-package: jdk
-          architecture: x86
       - name: Build Documentation
         run: |
+          java -version
           chmod +x ./gradlew
           ./gradlew build dokkaHtml
         env:

--- a/.github/workflows/execute-samples.yml
+++ b/.github/workflows/execute-samples.yml
@@ -5,13 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          java-package: jdk
-          architecture: x86
       - name: Build main project
         run: |
+          java -version
           chmod +x ./gradlew
           ./gradlew build
         env:

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -5,18 +5,13 @@ jobs:
     name: Execute Test Suite
     strategy:
       matrix:
-        architecture: [x64, x86]
         operating-system: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-          java-package: jdk
-          architecture: ${{ matrix.architecture }}
       - name: Run Tests
         run: |
+          java -version
           chmod +x ./gradlew
           ./gradlew clean build test --refresh-dependencies
         env:


### PR DESCRIPTION
This GitHub action was causing issues for all builds because somebody at Zulu had removed a Java macos 8 binary so the entire test suite would collapse.

It looks like all of GitHub's virtual environment which the Actions runners run inside have Java available which means this plugin is not necessary anymore unless we wish to upgrade to a later or specific Java version. This can also be done with the system package manager if we decide to go that route.