### PR TITLE
[dependencies] upgrade to bytedeco/javacpp-presets 1.5.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0-rc")
-    implementation("org.bytedeco:llvm-platform:10.0.0-1.5.3")
+    implementation("org.bytedeco:llvm-platform:10.0.1-1.5.4")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.4.0-rc")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:2.0.11")

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/executionengine/callbacks/MemoryManagerFinalizeMemoryCallback.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/executionengine/callbacks/MemoryManagerFinalizeMemoryCallback.kt
@@ -1,8 +1,10 @@
 package io.vexelabs.bitbuilder.llvm.executionengine.callbacks
 
 import io.vexelabs.bitbuilder.llvm.internal.contracts.Callback
+import io.vexelabs.bitbuilder.llvm.internal.util.map
 import org.bytedeco.javacpp.BytePointer
 import org.bytedeco.javacpp.Pointer
+import org.bytedeco.javacpp.PointerPointer
 import org.bytedeco.llvm.LLVM.LLVMMemoryManagerFinalizeMemoryCallback
 
 /**
@@ -28,17 +30,27 @@ public data class MemoryManagerFinalizeMemoryCallbackContext(
 /**
  * Pointer type for [LLVMMemoryManagerFinalizeMemoryCallback]
  *
- * This is the value passed back int oLLVM
+ * This is the value passed back into LLVM
+ *
+ * TODO: Find a reliable way of testing this (see #179)
  *
  * @see LLVMMemoryManagerFinalizeMemoryCallback
  */
 public class MemoryManagerFinalizeMemoryBase(
     private val callback: MemoryManagerFinalizeMemoryCallback
 ) : LLVMMemoryManagerFinalizeMemoryCallback(), Callback {
-    public override fun call(arg0: Pointer?, arg1: BytePointer?): Int {
+    public override fun call(
+        arg0: Pointer?,
+        arg1: PointerPointer<*>?
+    ): Int {
+        val msg = (arg1 as? PointerPointer<BytePointer>)
+            ?.map { it.string }
+            ?.joinToString("\n")
+            ?: ""
+
         val data = MemoryManagerFinalizeMemoryCallbackContext(
             payload = arg0,
-            error = arg1?.string ?: ""
+            error = msg
         )
 
         return callback.invoke(data)


### PR DESCRIPTION
This PR upgrades the llvm-platform dependency to LLVM 10.0.1 / javacpp-1.5.4.

This update is performed to pull in the mission LLVM Target APIs which were previously not built for javacpp.

- see [CHANGELOG.md#september-9-2020-version-154](https://github.com/bytedeco/javacpp-presets/blob/master/CHANGELOG.md#september-9-2020-version-154)