### PR TITLE
[api] Create custom RTTI to allow cast<T> between wrapper types

### DIFF
--- a/src/main/kotlin/io/vexelabs/bitbuilder/rtti/Casting.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/rtti/Casting.kt
@@ -1,14 +1,60 @@
 package io.vexelabs.bitbuilder.rtti
 
+import com.sun.jdi.FloatType
 import io.vexelabs.bitbuilder.llvm.internal.contracts.ContainsReference
 import io.vexelabs.bitbuilder.llvm.ir.Instruction
+import io.vexelabs.bitbuilder.llvm.ir.User
+import io.vexelabs.bitbuilder.llvm.ir.instructions.AllocaInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.AtomicCmpXchgInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.AtomicRMWInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.BrInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.CallBrInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.CallInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.CatchPadInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.CatchRetInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.CatchSwitchInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.CleanupPadInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.CleanupRetInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.FenceInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.IndirectBrInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.InvokeInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.LandingPadInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.LoadInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.PhiInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.ResumeInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.RetInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.SelectInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.StoreInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.SwitchInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.UnreachableInstruction
+import io.vexelabs.bitbuilder.llvm.ir.instructions.VAArgInstruction
+import io.vexelabs.bitbuilder.llvm.ir.types.FunctionType
+import io.vexelabs.bitbuilder.llvm.ir.types.IntType
+import io.vexelabs.bitbuilder.llvm.ir.types.LabelType
+import io.vexelabs.bitbuilder.llvm.ir.types.MetadataType
+import io.vexelabs.bitbuilder.llvm.ir.types.PointerType
+import io.vexelabs.bitbuilder.llvm.ir.types.StructType
+import io.vexelabs.bitbuilder.llvm.ir.types.TokenType
+import io.vexelabs.bitbuilder.llvm.ir.types.VectorType
+import io.vexelabs.bitbuilder.llvm.ir.types.VoidType
+import io.vexelabs.bitbuilder.llvm.ir.types.X86MMXType
+import io.vexelabs.bitbuilder.llvm.ir.values.ConstantValue
+import io.vexelabs.bitbuilder.llvm.ir.values.FunctionValue
+import io.vexelabs.bitbuilder.llvm.ir.values.GlobalAlias
+import io.vexelabs.bitbuilder.llvm.ir.values.GlobalValue
+import io.vexelabs.bitbuilder.llvm.ir.values.GlobalVariable
+import io.vexelabs.bitbuilder.llvm.ir.values.IndirectFunction
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantArray
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantFloat
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantPointer
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantStruct
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantVector
 import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMTypeRef
 import org.bytedeco.llvm.LLVM.LLVMValueRef
 import java.lang.reflect.Constructor
+import javax.lang.model.type.ArrayType
 
 /**
  * Helper function to retrieve the java.lang.Class<[T]> and the constructor of
@@ -18,7 +64,7 @@ import java.lang.reflect.Constructor
  *
  * This is only for internal usage to map out RTTI casting paths
  */
-private inline fun <reified T, reified P : Pointer> getConstructor():
+private inline fun <reified T, reified P : Pointer> path():
         Pair<Class<T>, Constructor<T>> {
     val clazz = T::class.java
     val ptr = P::class.java
@@ -30,15 +76,65 @@ private inline fun <reified T, reified P : Pointer> getConstructor():
  * A lazy map listing all the valid type casting paths, meaning that the
  * BitBuilder type can be constructed with the JavaCPP Pointer Type
  *
- * @see getConstructor
+ * @see path
  */
 public val constructorMap: Map<Class<*>, Constructor<*>> by lazy {
     mapOf(
-        getConstructor<ConstantInt, LLVMValueRef>(),
-        getConstructor<ConstantVector, LLVMValueRef>(),
-        getConstructor<ConstantStruct, LLVMValueRef>(),
-        getConstructor<ConstantPointer, LLVMValueRef>(),
-        getConstructor<Instruction, LLVMValueRef>(),
+        // Basic Values
+        path<FunctionValue, LLVMValueRef>(),
+        path<IndirectFunction, LLVMValueRef>(),
+        path<GlobalValue, LLVMValueRef>(),
+        path<GlobalVariable, LLVMValueRef>(),
+        path<GlobalAlias, LLVMValueRef>(),
+        // Constant Values
+        path<ConstantValue, LLVMValueRef>(),
+        path<ConstantInt, LLVMValueRef>(),
+        path<ConstantVector, LLVMValueRef>(),
+        path<ConstantStruct, LLVMValueRef>(),
+        path<ConstantPointer, LLVMValueRef>(),
+        path<ConstantFloat, LLVMValueRef>(),
+        path<ConstantArray, LLVMValueRef>(),
+        // Types
+        path<ArrayType, LLVMTypeRef>(),
+        path<FloatType, LLVMTypeRef>(),
+        path<FunctionType, LLVMTypeRef>(),
+        path<IntType, LLVMTypeRef>(),
+        path<LabelType, LLVMTypeRef>(),
+        path<MetadataType, LLVMTypeRef>(),
+        path<PointerType, LLVMTypeRef>(),
+        path<StructType, LLVMTypeRef>(),
+        path<TokenType, LLVMTypeRef>(),
+        path<VectorType, LLVMTypeRef>(),
+        path<VoidType, LLVMTypeRef>(),
+        path<X86MMXType, LLVMTypeRef>(),
+        // Users
+        path<User, LLVMValueRef>(),
+        // Instructions
+        path<Instruction, LLVMValueRef>(),
+        path<AllocaInstruction, LLVMValueRef>(),
+        path<AtomicCmpXchgInstruction, LLVMValueRef>(),
+        path<AtomicRMWInstruction, LLVMValueRef>(),
+        path<BrInstruction, LLVMValueRef>(),
+        path<CallBrInstruction, LLVMValueRef>(),
+        path<CallInstruction, LLVMValueRef>(),
+        path<CatchPadInstruction, LLVMValueRef>(),
+        path<CatchRetInstruction, LLVMValueRef>(),
+        path<CatchSwitchInstruction, LLVMValueRef>(),
+        path<CleanupPadInstruction, LLVMValueRef>(),
+        path<CleanupRetInstruction, LLVMValueRef>(),
+        path<FenceInstruction, LLVMValueRef>(),
+        path<IndirectBrInstruction, LLVMValueRef>(),
+        path<InvokeInstruction, LLVMValueRef>(),
+        path<LandingPadInstruction, LLVMValueRef>(),
+        path<LoadInstruction, LLVMValueRef>(),
+        path<PhiInstruction, LLVMValueRef>(),
+        path<ResumeInstruction, LLVMValueRef>(),
+        path<RetInstruction, LLVMValueRef>(),
+        path<SelectInstruction, LLVMValueRef>(),
+        path<StoreInstruction, LLVMValueRef>(),
+        path<SwitchInstruction, LLVMValueRef>(),
+        path<UnreachableInstruction, LLVMValueRef>(),
+        path<VAArgInstruction, LLVMValueRef>()
     )
 }
 

--- a/src/main/kotlin/io/vexelabs/bitbuilder/rtti/Casting.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/rtti/Casting.kt
@@ -1,0 +1,79 @@
+package io.vexelabs.bitbuilder.rtti
+
+import io.vexelabs.bitbuilder.llvm.internal.contracts.ContainsReference
+import io.vexelabs.bitbuilder.llvm.ir.Instruction
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantPointer
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantStruct
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantVector
+import org.bytedeco.javacpp.Pointer
+import org.bytedeco.llvm.LLVM.LLVMValueRef
+import java.lang.reflect.Constructor
+
+/**
+ * Helper function to retrieve the java.lang.Class<[T]> and the constructor of
+ * said class which accepts [P]
+ *
+ * For this to be valid, type [T] should be able to be constructed from type [P]
+ *
+ * This is only for internal usage to map out RTTI casting paths
+ */
+private inline fun <reified T, reified P : Pointer> getConstructor():
+        Pair<Class<T>, Constructor<T>> {
+    val clazz = T::class.java
+    val ptr = P::class.java
+
+    return Pair(clazz, clazz.getConstructor(ptr))
+}
+
+/**
+ * A lazy map listing all the valid type casting paths, meaning that the
+ * BitBuilder type can be constructed with the JavaCPP Pointer Type
+ *
+ * @see getConstructor
+ */
+public val constructorMap: Map<Class<*>, Constructor<*>> by lazy {
+    mapOf(
+        getConstructor<ConstantInt, LLVMValueRef>(),
+        getConstructor<ConstantVector, LLVMValueRef>(),
+        getConstructor<ConstantStruct, LLVMValueRef>(),
+        getConstructor<ConstantPointer, LLVMValueRef>(),
+        getConstructor<Instruction, LLVMValueRef>(),
+    )
+}
+
+/**
+ * Cast the provided value, [self] into type [T] using unsafe RTTI
+ *
+ * For this cast to succeed, the type of [self] should be able to be
+ * constructed with a single argument [T]
+ *
+ * @see constructorMap for valid casting paths
+ */
+public inline fun <reified T> castOrNull(self: ContainsReference<*>): T? {
+    return constructorMap.getOrElse(T::class.java) { null }
+        ?.newInstance(self.ref) as? T
+}
+
+/**
+ * Cast the provided value, [v] into [T] using unsafe RTTI, if the path for
+ * this cast does not exist, return [default]
+ */
+public inline fun <reified T> castOrElse(
+    v: ContainsReference<*>,
+    default: () -> T
+): T {
+    return castOrNull<T>(v) ?: default.invoke()
+}
+
+/**
+ * Cast the provided value, [v] into [T] using unsafe RTTI, if the path for
+ * this cast does not exist, throw an [IllegalArgumentException]
+ *
+ * @throws IllegalArgumentException
+ */
+public inline fun <reified T> cast(v: ContainsReference<*>): T {
+    return castOrNull<T>(v) ?: throw IllegalArgumentException(
+        "Could not find valid path to ${T::class.simpleName}"
+    )
+}

--- a/src/main/kotlin/io/vexelabs/bitbuilder/rtti/Casting.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/rtti/Casting.kt
@@ -74,6 +74,9 @@ public inline fun <reified T, P : Pointer> path(
  *
  * @see cast
  * @see path
+ *
+ * TODO: This Map type is very hacky, should replace Any with an actual
+ *   function type.
  */
 public val constructorMap: Map<Class<*>, Any> =
     mapOf(
@@ -141,6 +144,8 @@ public val constructorMap: Map<Class<*>, Any> =
  * constructed with a single argument [T]
  *
  * @see constructorMap for valid casting paths
+ *
+ * TODO: Fix unchecked cast warning, find proper type
  */
 @Suppress("UNCHECKED_CAST")
 public inline fun <reified T> castOrNull(self: ContainsReference<*>): T? {

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/instructions/BrInstructionTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/instructions/BrInstructionTest.kt
@@ -6,6 +6,7 @@ import io.vexelabs.bitbuilder.llvm.ir.types.FunctionType
 import io.vexelabs.bitbuilder.llvm.ir.types.IntType
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
 import io.vexelabs.bitbuilder.llvm.setup
+import io.vexelabs.bitbuilder.rtti.cast
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -41,7 +42,7 @@ internal class BrInstructionTest : Spek({
         val condition = ConstantInt(IntType(1), 1)
 
         val subject = builder.createCondBr(condition, then, otherwise)
-        val foundCondition = ConstantInt(subject.getCondition().ref)
+        val foundCondition = cast<ConstantInt>(condition)
 
         assertEquals(condition.ref, foundCondition.ref)
         assertTrue { subject.isConditional() }

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/types/FunctionTypeTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/types/FunctionTypeTest.kt
@@ -31,7 +31,7 @@ internal class FunctionTypeTest : Spek({
         val args = listOf(FloatType(TypeKind.Float))
         val fn = FunctionType(ret, args, true)
 
-        assertEquals(LLVM.LLVMCountParamTypes(fn.ref), fn.getParameterCount())
+        assertEquals(1, fn.getParameterCount())
     }
 
     test("the passed parameters match") {

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/GlobalAliasTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/GlobalAliasTest.kt
@@ -4,6 +4,7 @@ import io.vexelabs.bitbuilder.llvm.ir.Module
 import io.vexelabs.bitbuilder.llvm.ir.types.IntType
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
 import io.vexelabs.bitbuilder.llvm.setup
+import io.vexelabs.bitbuilder.rtti.cast
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import org.spekframework.spek2.Spek
@@ -25,8 +26,8 @@ internal class GlobalAliasTest : Spek({
         val aliasValue = alias.getAliasOf()
 
         assertEquals(
-            ConstantInt(aliasValue.ref).getSignedValue(),
-            ConstantInt(global.ref).getSignedValue()
+            cast<ConstantInt>(aliasValue).getSignedValue(),
+            cast<ConstantInt>(global).getSignedValue()
         )
     }
 

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/GlobalValueTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/GlobalValueTest.kt
@@ -8,6 +8,7 @@ import io.vexelabs.bitbuilder.llvm.ir.Visibility
 import io.vexelabs.bitbuilder.llvm.ir.types.IntType
 import io.vexelabs.bitbuilder.llvm.ir.values.GlobalValue
 import io.vexelabs.bitbuilder.llvm.setup
+import io.vexelabs.bitbuilder.rtti.cast
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -93,7 +94,7 @@ internal class GlobalValueTest : Spek({
         module.setModuleIdentifier("basic")
 
         val global = module.addGlobal("my_int", IntType(32))
-        val globalModule = GlobalValue(global.ref).getModule()
+        val globalModule = cast<GlobalValue>(global).getModule()
 
         assertEquals(
             module.getModuleIdentifier(), globalModule.getModuleIdentifier()

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/GlobalVariableTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/GlobalVariableTest.kt
@@ -6,6 +6,7 @@ import io.vexelabs.bitbuilder.llvm.ir.types.IntType
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
 import io.vexelabs.bitbuilder.llvm.setup
 import io.vexelabs.bitbuilder.llvm.utils.runAll
+import io.vexelabs.bitbuilder.rtti.cast
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -29,7 +30,7 @@ internal class GlobalVariableTest : Spek({
             assertFalse { isThreadLocal() }
             assertFalse { isExternallyInitialized() }
 
-            val initializer = ConstantInt(value.getInitializer()!!.ref)
+            val initializer = cast<ConstantInt>(value.getInitializer()!!)
                 .getSignedValue()
 
             assertEquals(100L, initializer)

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/constants/ConstantArrayTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/constants/ConstantArrayTest.kt
@@ -4,6 +4,7 @@ import io.vexelabs.bitbuilder.llvm.ir.types.IntType
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantArray
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
 import io.vexelabs.bitbuilder.llvm.utils.constIntPairOf
+import io.vexelabs.bitbuilder.rtti.cast
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.spekframework.spek2.Spek
@@ -27,7 +28,7 @@ internal class ConstantArrayTest : Spek({
 
         assertEquals(
             one.getSignedValue(),
-            ConstantInt(first.ref).getSignedValue()
+            cast<ConstantInt>(first).getSignedValue()
         )
     }
 })

--- a/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/constants/ConstantIntTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/llvm/unit/ir/values/constants/ConstantIntTest.kt
@@ -8,6 +8,7 @@ import io.vexelabs.bitbuilder.llvm.ir.types.PointerType
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
 import io.vexelabs.bitbuilder.llvm.utils.constIntPairOf
 import io.vexelabs.bitbuilder.llvm.utils.runAll
+import io.vexelabs.bitbuilder.rtti.cast
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -258,6 +259,6 @@ internal class ConstantIntTest : Spek({
 
         val res = cond.getSelect(lhs, rhs)
 
-        assertEquals(10, ConstantInt(res.ref).getSignedValue())
+        assertEquals(10, cast<ConstantInt>(res).getSignedValue())
     }
 })

--- a/src/test/kotlin/io/vexelabs/bitbuilder/rtti/CastingTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/rtti/CastingTest.kt
@@ -1,10 +1,14 @@
 package io.vexelabs.bitbuilder.rtti
 
+import io.vexelabs.bitbuilder.llvm.ir.Use
 import io.vexelabs.bitbuilder.llvm.ir.Value
 import io.vexelabs.bitbuilder.llvm.ir.types.IntType
 import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
 import org.spekframework.spek2.Spek
+import kotlin.system.measureNanoTime
+import kotlin.system.measureTimeMillis
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 internal object CastingTest : Spek({
     test("casting between valid paths") {
@@ -13,5 +17,15 @@ internal object CastingTest : Spek({
         val int = cast<ConstantInt>(value)
 
         assertEquals(1, int.getSignedValue())
+    }
+
+    test("invalid paths will fail") {
+        // Use has a constructor from LLVMValueRef, but is not a valid path
+        // Path: Value -> Use : LLVMValueRef
+        val value: Value = ConstantInt(IntType(32), 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            cast<Use>(value)
+        }
     }
 })

--- a/src/test/kotlin/io/vexelabs/bitbuilder/rtti/CastingTest.kt
+++ b/src/test/kotlin/io/vexelabs/bitbuilder/rtti/CastingTest.kt
@@ -1,0 +1,17 @@
+package io.vexelabs.bitbuilder.rtti
+
+import io.vexelabs.bitbuilder.llvm.ir.Value
+import io.vexelabs.bitbuilder.llvm.ir.types.IntType
+import io.vexelabs.bitbuilder.llvm.ir.values.constants.ConstantInt
+import org.spekframework.spek2.Spek
+import kotlin.test.assertEquals
+
+internal object CastingTest : Spek({
+    test("casting between valid paths") {
+        // Path: Value -> ConstantInt : LLVMValueRef
+        val value: Value = ConstantInt(IntType(32), 1)
+        val int = cast<ConstantInt>(value)
+
+        assertEquals(1, int.getSignedValue())
+    }
+})


### PR DESCRIPTION
It's not possible to represent the LLVM type system through Kotlin which means Kotlin-style casts between wrapper types will always fail as they're two different types.

A user should be able to cast between these types, because the reference the wrapper classes hold may be casted and tossed around which is why we need a cast api.

By building our own "rtti" we can provide a `cast<T>(value)` API which will be able to mimic we could perform if we were using the LLVM C++ API.