### PR TITLE
[samples] make samples use local file only on ci machines

### DIFF
--- a/samples/factorial-jit/build.gradle.kts
+++ b/samples/factorial-jit/build.gradle.kts
@@ -16,11 +16,15 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0-rc")
     implementation("org.bytedeco:llvm-platform:10.0.1-1.5.4")
-    // For standalone usage, uncomment this line...
-    // implementation("com.github.vexelabs:bitbuilder:-SNAPSHOT")
 
-    // And comment out this one
-    implementation(fileTree("../../build/libs"))
+    // @internal: run a local build on CI machines
+    // regular users should use
+    // implementation("com.github.vexelabs:bitbuilder:-SNAPSHOT")
+    if (System.getProperty("CI") == "true") {
+        implementation(fileTree("../../build/libs"))
+    } else {
+        implementation("com.github.vexelabs:bitbuilder:-SNAPSHOT")
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {


### PR DESCRIPTION
Right now, there are manual instructions and replacement required to run a sample which shouldn't be there.

This patch decides which bitbuilder version to pull depending on whether we're running on a CI machine or not. If the code is ran in CI, the locally built jar will be used, otherwise, the one from mavencentral should be used.

To force run the local jar you simply set `CI=true` in your environment before running.