### PR TITLE
Update dependencies from kotlin 1.4.0 -rc to 1.4.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.github.johnrengelman.shadow") version "5.2.0"
     id("org.jetbrains.dokka") version "1.4.0-rc"
-    id("org.jetbrains.kotlin.jvm") version "1.4.0-rc"
+    id("org.jetbrains.kotlin.jvm") version "1.4.10"
     id("maven")
 }
 
@@ -15,13 +15,13 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0-rc")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10")
     implementation("org.bytedeco:llvm-platform:10.0.1-1.5.4")
 
-    testImplementation("org.jetbrains.kotlin:kotlin-test:1.4.0-rc")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.4.10")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:2.0.11")
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:2.0.11")
-    testRuntimeOnly("org.jetbrains.kotlin:kotlin-reflect:1.4.0-rc")
+    testRuntimeOnly("org.jetbrains.kotlin:kotlin-reflect:1.4.10")
 }
 
 kotlin {


### PR DESCRIPTION
Type : Chore
Subject : Update dependencies from Kotlin 1.4.0- rc to 1.4.10

Dependencies and plugins are updated to latest version. However, plugin id "org.jetbrains.dokka" isn't updated to latest version because version 1.4.10 of the plugin is in alpha state. 