### PR TITLE
[dependencies] Upgrade to LLVM 11.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,11 +22,12 @@ repositories {
     mavenCentral()
     maven("https://jitpack.io")
     maven("https://jcenter.bintray.com")
+    maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10")
-    implementation("org.bytedeco:llvm-platform:10.0.1-1.5.4")
+    implementation("org.bytedeco:llvm-platform:11.0.0-1.5.5-SNAPSHOT")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.4.10")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:2.0.11")

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Flags.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/Flags.kt
@@ -141,13 +141,13 @@ public enum class AtomicRMWBinaryOperation(public override val value: Int) :
     }
 }
 
-public enum class AttributeIndex(public override val value: Long) :
-    ForeignEnum<Long> {
+public enum class AttributeIndex(public override val value: Int) :
+    ForeignEnum<Int> {
     Return(LLVM.LLVMAttributeReturnIndex),
     Function(LLVM.LLVMAttributeFunctionIndex);
 
-    public companion object : ForeignEnum.CompanionBase<Long, AttributeIndex> {
-        public override val map: Map<Long, AttributeIndex> by lazy {
+    public companion object : ForeignEnum.CompanionBase<Int, AttributeIndex> {
+        public override val map: Map<Int, AttributeIndex> by lazy {
             values().associateBy(AttributeIndex::value)
         }
     }

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/instructions/traits/CallBase.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/instructions/traits/CallBase.kt
@@ -72,7 +72,7 @@ public interface CallBase : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMAddCallSiteAttribute
      */
     public fun addAttribute(index: AttributeIndex, attribute: Attribute) {
-        return addAttribute(index.value.toInt(), attribute)
+        return addAttribute(index.value, attribute)
     }
 
     /**
@@ -90,7 +90,7 @@ public interface CallBase : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMGetCallSiteAttributeCount
      */
     public fun getAttributeCount(index: AttributeIndex): Int {
-        return getAttributeCount(index.value.toInt())
+        return getAttributeCount(index.value)
     }
 
     /**
@@ -135,7 +135,7 @@ public interface CallBase : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMGetCallSiteEnumAttribute
      */
     public fun getEnumAttribute(index: AttributeIndex, kind: Int): Attribute? {
-        return getEnumAttribute(index.value.toInt(), kind)
+        return getEnumAttribute(index.value, kind)
     }
 
     /**
@@ -160,7 +160,7 @@ public interface CallBase : ContainsReference<LLVMValueRef> {
         index: AttributeIndex,
         kind: String
     ): Attribute? {
-        return getStringAttribute(index.value.toInt(), kind)
+        return getStringAttribute(index.value, kind)
     }
 
     /**
@@ -183,7 +183,7 @@ public interface CallBase : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMRemoveCallSiteEnumAttribute
      */
     public fun removeEnumAttribute(index: AttributeIndex, kind: Int) {
-        removeEnumAttribute(index.value.toInt(), kind)
+        removeEnumAttribute(index.value, kind)
     }
 
     /**
@@ -203,7 +203,7 @@ public interface CallBase : ContainsReference<LLVMValueRef> {
      * @see LLVM.LLVMRemoveCallSiteStringAttribute
      */
     public fun removeStringAttribute(index: AttributeIndex, kind: String) {
-        removeStringAttribute(index.value.toInt(), kind)
+        removeStringAttribute(index.value, kind)
     }
 
     /**

--- a/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/FunctionValue.kt
+++ b/src/main/kotlin/io/vexelabs/bitbuilder/llvm/ir/values/FunctionValue.kt
@@ -306,7 +306,7 @@ public open class FunctionValue internal constructor() :
             getAttributeCount(index).toLong()
         )
 
-        LLVM.LLVMGetAttributesAtIndex(ref, index.value.toInt(), ptr)
+        LLVM.LLVMGetAttributesAtIndex(ref, index.value, ptr)
 
         return ptr.map { Attribute.create(it) }
     }
@@ -321,7 +321,7 @@ public open class FunctionValue internal constructor() :
     public fun getEnumAttribute(
         index: AttributeIndex,
         kind: Int
-    ): AttributeEnum? = getEnumAttribute(index.value.toInt(), kind)
+    ): AttributeEnum? = getEnumAttribute(index.value, kind)
 
     /**
      * Pull the attribute value from an [index] with a [kind]


### PR DESCRIPTION
Closes #199 
Closes #196

Upgrades the bytedeco:llvm-platform dependency to LLVM 11.

Full changelog for presets can be found here: https://github.com/bytedeco/javacpp-presets/commit/23ff3500ba310f27779cf7acc87aa1d56c607264#diff-ef5a927f5a4ae8bdfa7d187079fa7b2aabc8d72ce219c564f78c9498ff59d2f9