### PR TITLE
[build] add mavenlocal to maven repositories

### DIFF
--- a/.dependencies/dependencies.pom.xml
+++ b/.dependencies/dependencies.pom.xml
@@ -1,0 +1,25 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.vexelabs.bitbuilder</groupId>
+    <artifactId>dependencies</artifactId>
+    <version>1.0.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>llvm-platform</artifactId>
+            <version>11.0.0-1.5.5-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+    <repositories>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Log system information
         run: |
           bash --version
-          bash ./gradlew --verion
+          bash ./gradlew --version
           java -version
 
       - name: Execute kotlin test suite

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -10,53 +10,51 @@ env:
   GRADLE_OPTS: -Dorg.gradle.caching=true
 jobs:
   lint:
-    name: Ensure code style follows ktlint guidelines
+    name: Style-check codebase
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Run ktlint
+      - name: Install Dependencies
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
-          bash ./gradlew ktlintCheck
+          bash ./gradlew clean build --refresh-dependencies
+
+      - uses: actions/checkout@v2
+      - name: Run ktlint
+        run: bash ./gradlew ktlintCheck
+
   test:
-    name: Test Suite
+    name: Execute test suite
     strategy:
       matrix:
         operating-system: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Log and prepare environment information
-        run: java -version
-
-      - name: Fetch Gradle dependencies
+      - name: Install Dependencies
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
-          bash ./gradlew clean --refresh-dependencies
+          bash ./gradlew clean build --refresh-dependencies
 
-      - name: Build project from source
-        run: bash ./gradlew build
+      - uses: actions/checkout@v2
+      - name: Log system information
+        run: |
+          bash --version
+          bash ./gradlew --verion
+          java -version
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: main-project-build
-          path: build/
-
-      - name: Execute Kotlin tests
+      - name: Execute kotlin test suite
         run: bash ./gradlew test
+
   samples:
     needs: [test]
     name: Ensure sample projects run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build parent project
+      - name: Install Dependencies
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
-          bash ./gradlew build --refresh-dependencies
+          bash ./gradlew clean build --refresh-dependencies
+
+      - uses: actions/checkout@v2
 
       - name: FactorialJIT Example
         run: bash samples/run.sh factorial-jit

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Run ktlint
-        run: bash ./gradlew ktlintCheck
+        run: |
+          mvn -f .dependencies/dependencies.pom.xml -U compile
+          bash ./gradlew ktlintCheck
   test:
     name: Test Suite
     strategy:
@@ -24,16 +27,23 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2
+
       - name: Log and prepare environment information
         run: java -version
+
       - name: Fetch Gradle dependencies
-        run: bash ./gradlew clean --refresh-dependencies
+        run: |
+          mvn -f .dependencies/dependencies.pom.xml -U compile
+          bash ./gradlew clean --refresh-dependencies
+
       - name: Build project from source
         run: bash ./gradlew build
+
       - uses: actions/upload-artifact@v2
         with:
           name: main-project-build
           path: build/
+
       - name: Execute Kotlin tests
         run: bash ./gradlew test
   samples:
@@ -42,7 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Build parent project
-        run: bash ./gradlew build --refresh-dependencies
+        run: |
+          mvn -f .dependencies/dependencies.pom.xml -U compile
+          bash ./gradlew build --refresh-dependencies
+
       - name: FactorialJIT Example
         run: bash samples/run.sh factorial-jit

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -13,12 +13,12 @@ jobs:
     name: Style-check codebase
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
           bash ./gradlew clean build --refresh-dependencies
 
-      - uses: actions/checkout@v2
       - name: Run ktlint
         run: bash ./gradlew ktlintCheck
 
@@ -29,12 +29,12 @@ jobs:
         operating-system: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
+      - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
           bash ./gradlew clean build --refresh-dependencies
 
-      - uses: actions/checkout@v2
       - name: Log system information
         run: |
           bash --version
@@ -49,12 +49,11 @@ jobs:
     name: Ensure sample projects run
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
           bash ./gradlew clean build --refresh-dependencies
-
-      - uses: actions/checkout@v2
 
       - name: FactorialJIT Example
         run: bash samples/run.sh factorial-jit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ val isSnapshot = version.toString().endsWith("SNAPSHOT")
 
 repositories {
     mavenCentral()
+    mavenLocal()
     maven("https://jitpack.io")
     maven("https://jcenter.bintray.com")
     maven("https://oss.sonatype.org/content/repositories/snapshots")


### PR DESCRIPTION
To solve the issue with Gradle failing to download artifacts with classifiers, we're going to install the dependencies through maven locally (see http://bytedeco.org/builds/#other-options) and then fetch those from mavenLocal while we're on the SNAPSHOT release.