### PR TITLE
[build] cache dependencies in github actions

### DIFF
--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -14,7 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      # Cache dependencies per commit hash because Sonatype OSS repo might
+      # miss certain artifacts at times.
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: @actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
+          restore-keys: ${{ runner.os }}-hash-
+      # Install dependencies if git hash has changed
       - name: Install Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
           bash ./gradlew clean build --refresh-dependencies
@@ -30,7 +42,19 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2
+
+      # Cache dependencies per commit hash because Sonatype OSS repo might
+      # miss certain artifacts at times.
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: @actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
+          restore-keys: ${{ runner.os }}-hash-
+      # Install dependencies if git hash has changed
       - name: Install Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
           bash ./gradlew clean build --refresh-dependencies
@@ -50,7 +74,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      # Cache dependencies per commit hash because Sonatype OSS repo might
+      # miss certain artifacts at times.
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: @actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
+          restore-keys: ${{ runner.os }}-hash-
+      # Install dependencies if git hash has changed
       - name: Install Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           mvn -f .dependencies/dependencies.pom.xml -U compile
           bash ./gradlew clean build --refresh-dependencies

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -19,7 +19,7 @@ jobs:
       # miss certain artifacts at times.
       - name: Cache Dependencies
         id: cache-deps
-        uses: @actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
@@ -47,7 +47,7 @@ jobs:
       # miss certain artifacts at times.
       - name: Cache Dependencies
         id: cache-deps
-        uses: @actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
@@ -79,7 +79,7 @@ jobs:
       # miss certain artifacts at times.
       - name: Cache Dependencies
         id: cache-deps
-        uses: @actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031


### PR DESCRIPTION
Because of recent changes in the way bytedeco deploys artifacts through CI, we are better off caching the dependencies pulled from maven. This means gradle dependencies won't be cached.

Dependencies are cached based on git hash from the bytedeco/javacpp upstream. Current hash points to https://github.com/bytedeco/javacpp-presets/commit/df754038083bf5f352298666ce1c9cfb9843b031