### PR TITLE
[ci] use constant hash for caching dependencies

### DIFF
--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
+          key: mvn-hash-df754038083bf5f352298666ce1c9cfb9843b031
           restore-keys: ${{ runner.os }}-hash-
       # Install dependencies if git hash has changed
       - name: Install Dependencies
@@ -35,6 +35,7 @@ jobs:
         run: bash ./gradlew ktlintCheck
 
   test:
+    needs: [lint]
     name: Execute test suite
     strategy:
       matrix:
@@ -50,7 +51,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
+          key: mvn-hash-df754038083bf5f352298666ce1c9cfb9843b031
           restore-keys: ${{ runner.os }}-hash-
       # Install dependencies if git hash has changed
       - name: Install Dependencies
@@ -82,7 +83,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-hash-df754038083bf5f352298666ce1c9cfb9843b031
+          key: mvn-hash-df754038083bf5f352298666ce1c9cfb9843b031
           restore-keys: ${{ runner.os }}-hash-
       # Install dependencies if git hash has changed
       - name: Install Dependencies

--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -23,13 +23,13 @@ jobs:
         with:
           path: ~/.m2/repository
           key: mvn-hash-df754038083bf5f352298666ce1c9cfb9843b031
-          restore-keys: ${{ runner.os }}-hash-
       # Install dependencies if git hash has changed
-      - name: Install Dependencies
+      - name: Install Maven Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          mvn -f .dependencies/dependencies.pom.xml -U compile
-          bash ./gradlew clean build --refresh-dependencies
+        run: mvn -f .dependencies/dependencies.pom.xml -U compile
+
+      - name: Install Gradle dependencies
+        run: bash ./gradlew clean build --refresh-dependencies
 
       - name: Run ktlint
         run: bash ./gradlew ktlintCheck
@@ -52,13 +52,13 @@ jobs:
         with:
           path: ~/.m2/repository
           key: mvn-hash-df754038083bf5f352298666ce1c9cfb9843b031
-          restore-keys: ${{ runner.os }}-hash-
       # Install dependencies if git hash has changed
       - name: Install Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          mvn -f .dependencies/dependencies.pom.xml -U compile
-          bash ./gradlew clean build --refresh-dependencies
+        run: mvn -f .dependencies/dependencies.pom.xml -U compile
+
+      - name: Install Gradle dependencies
+        run: bash ./gradlew clean build --refresh-dependencies
 
       - name: Log system information
         run: |
@@ -84,13 +84,13 @@ jobs:
         with:
           path: ~/.m2/repository
           key: mvn-hash-df754038083bf5f352298666ce1c9cfb9843b031
-          restore-keys: ${{ runner.os }}-hash-
       # Install dependencies if git hash has changed
       - name: Install Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          mvn -f .dependencies/dependencies.pom.xml -U compile
-          bash ./gradlew clean build --refresh-dependencies
+        run: mvn -f .dependencies/dependencies.pom.xml -U compile
+
+      - name: Install Gradle dependencies
+        run: bash ./gradlew clean build --refresh-dependencies
 
       - name: FactorialJIT Example
         run: bash samples/run.sh factorial-jit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ repositories {
     mavenLocal()
     maven("https://jitpack.io")
     maven("https://jcenter.bintray.com")
-    maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 dependencies {


### PR DESCRIPTION
The bytedeco dependency pull already pulls all platform jars so we might as well use the same cache key. To ensure it's actually cached and it reuses the dependencies, we make test depend on lint.